### PR TITLE
fix(ci): ignore missing docs/screenshots in artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,3 +275,4 @@ jobs:
           name: screenshots
           path: docs/screenshots/
           retention-days: 30
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Fixes CI warning: "No files were found with the provided path: docs/screenshots/. No artifacts will be uploaded."

## Changes

Added `if-no-files-found: ignore` to the screenshots upload step since `docs/screenshots/` doesn't exist yet (intended for future documentation).

## Test Plan

- CI should no longer show the warning