### PR TITLE
feat(ui): improve auth page accessibility and consistency

### DIFF
--- a/components/features/auth/login-form.tsx
+++ b/components/features/auth/login-form.tsx
@@ -16,15 +16,12 @@ import { Label } from "@/components/ui/label";
 import { authenticate } from "@/lib/actions/auth";
 
 export function LoginForm() {
-  const [errorMessage, formAction, isPending] = useActionState(
-    authenticate,
-    undefined
-  );
+  const [state, formAction, isPending] = useActionState(authenticate, undefined);
 
   return (
     <Card className="w-full max-w-sm">
       <CardHeader className="space-y-1">
-        <CardTitle className="text-2xl font-semibold tracking-tight">
+        <CardTitle as="h1" className="text-2xl font-semibold tracking-tight">
           Sign in
         </CardTitle>
         <CardDescription>Access your documents</CardDescription>
@@ -58,12 +55,12 @@ export function LoginForm() {
             />
           </div>
 
-          {errorMessage && (
+          {state?.error && (
             <div
               role="alert"
               className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
             >
-              {errorMessage}
+              {state.error}
             </div>
           )}
 

--- a/components/features/auth/register-form.tsx
+++ b/components/features/auth/register-form.tsx
@@ -21,7 +21,7 @@ export function RegisterForm() {
   return (
     <Card className="w-full max-w-sm">
       <CardHeader className="space-y-1">
-        <CardTitle className="text-2xl font-semibold tracking-tight">
+        <CardTitle as="h1" className="text-2xl font-semibold tracking-tight">
           Create account
         </CardTitle>
         <CardDescription>Start using BriefBot</CardDescription>

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -29,16 +29,19 @@ const CardHeader = React.forwardRef<
 ))
 CardHeader.displayName = "CardHeader"
 
-const CardTitle = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("font-semibold leading-none tracking-tight", className)}
-    {...props}
-  />
-))
+interface CardTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+}
+
+const CardTitle = React.forwardRef<HTMLHeadingElement, CardTitleProps>(
+  ({ className, as: Component = "h3", ...props }, ref) => (
+    <Component
+      ref={ref}
+      className={cn("font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  )
+);
 CardTitle.displayName = "CardTitle"
 
 const CardDescription = React.forwardRef<

--- a/lib/actions/auth.ts
+++ b/lib/actions/auth.ts
@@ -74,18 +74,19 @@ export async function register(
 }
 
 export async function authenticate(
-  _prevState: string | undefined,
+  _prevState: AuthActionResult | undefined,
   formData: FormData
-): Promise<string | undefined> {
+): Promise<AuthActionResult | undefined> {
   try {
     await signIn("credentials", formData);
+    return { success: true };
   } catch (error) {
     if (error instanceof AuthError) {
       switch (error.type) {
         case "CredentialsSignin":
-          return "Invalid email or password";
+          return { error: "Invalid email or password" };
         default:
-          return "Something went wrong";
+          return { error: "Something went wrong" };
       }
     }
     throw error;

--- a/tests/unit/components/ui/card.test.tsx
+++ b/tests/unit/components/ui/card.test.tsx
@@ -88,16 +88,36 @@ describe("CardTitle", () => {
     expect(title).toHaveClass("tracking-tight");
   });
 
-  it("renders as div element", () => {
+  it("renders as h3 element by default", () => {
     render(<CardTitle data-testid="title">Title</CardTitle>);
     const title = screen.getByTestId("title");
-    expect(title.tagName).toBe("DIV");
+    expect(title.tagName).toBe("H3");
+  });
+
+  it("renders as h1 when specified", () => {
+    render(
+      <CardTitle as="h1" data-testid="title">
+        Title
+      </CardTitle>
+    );
+    const title = screen.getByTestId("title");
+    expect(title.tagName).toBe("H1");
+  });
+
+  it("renders as h2 when specified", () => {
+    render(
+      <CardTitle as="h2" data-testid="title">
+        Title
+      </CardTitle>
+    );
+    const title = screen.getByTestId("title");
+    expect(title.tagName).toBe("H2");
   });
 
   it("forwards ref correctly", () => {
-    const ref = createRef<HTMLDivElement>();
+    const ref = createRef<HTMLHeadingElement>();
     render(<CardTitle ref={ref}>Title</CardTitle>);
-    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
   });
 
   it("applies custom className", () => {


### PR DESCRIPTION
## Summary

Second PR in the UI restyling series for #52. Focuses on auth page accessibility:

- **Semantic headings**: Make CardTitle polymorphic with `as` prop (h1-h6)
- **Auth page headings**: Use `as="h1"` for login/register pages
- **Error pattern standardization**: `authenticate` action now returns `AuthActionResult` matching `register`
- **Login form update**: Use `state?.error` pattern consistent with register form

### Files Changed

| File | Changes |
|------|---------|
| `components/ui/card.tsx` | Make CardTitle polymorphic with heading support |
| `components/features/auth/login-form.tsx` | Use h1 heading, standardized error pattern |
| `components/features/auth/register-form.tsx` | Use h1 heading |
| `lib/actions/auth.ts` | `authenticate` returns `AuthActionResult` |
| `tests/unit/components/ui/card.test.tsx` | Update tests for polymorphic CardTitle |

### Breaking Changes

- `CardTitle` now renders as `h3` by default instead of `div`
- `authenticate` action now returns `{error?: string}` instead of `string | undefined`

## Test plan

- [x] `npm run pre-pr` passes locally
- [ ] Verify auth page headings render as h1 in browser DevTools
- [ ] Verify login error state displays correctly
- [ ] Visual regression tests pass on CI

Part of #52