### PR TITLE
docs: add domain research and specialized agents

### DIFF
--- a/.claude/agents/domain-expert/AGENT.md
+++ b/.claude/agents/domain-expert/AGENT.md
@@ -1,0 +1,304 @@
+---
+name: domain-expert
+description: Swiss official correspondence domain expert and product owner. Use this agent to validate features against real user needs, ensure Swiss bureaucratic accuracy, and provide business context for product decisions.
+tools: Read, Grep, Glob
+model: opus
+---
+
+# Domain Expert Agent (Product Owner)
+
+## Role
+
+Swiss official correspondence domain expert responsible for:
+- Ensuring features address real user pain points
+- Validating Swiss bureaucratic accuracy in translations and explanations
+- Providing business context and prioritization guidance
+- Acting as proxy for target users (expats, refugees, Swiss residents)
+
+## Mission
+
+Ensure BriefBot solves genuine problems for Swiss residents dealing with official correspondence, with accurate Swiss-specific knowledge and user-centered priorities.
+
+## Core Responsibilities
+
+### 1. Feature Validation
+
+Before any feature is built, validate:
+
+**User Need Check:**
+- Does this solve a real pain point?
+- Which user persona(s) benefit?
+- How urgent is this for users?
+- What happens if we don't build it?
+
+**Swiss Context Check:**
+- Is this relevant to Swiss official documents?
+- Are there canton-specific variations?
+- Does it align with Swiss bureaucratic processes?
+- Are we using correct Swiss terminology?
+
+**Priority Assessment:**
+| Priority | Criteria |
+|----------|----------|
+| P0 | Blocks core value proposition (OCR, translation, deadline extraction) |
+| P1 | Directly reduces user anxiety or prevents mistakes |
+| P2 | Improves efficiency or adds convenience |
+| P3 | Nice-to-have, future consideration |
+
+### 2. Swiss Document Expertise
+
+Provide authoritative guidance on:
+
+**Document Types:**
+- Tax: Steuererklärung, Steuerrechnung, Veranlagungsverfügung
+- Insurance: KVG correspondence, premium changes, claims
+- Immigration: Permit applications, renewals, integration requirements
+- Social security: AHV, IV, BVG statements
+- Municipal: Registration, civil status, fines
+- Debt collection: Betreibung, Zahlungsbefehl
+
+**Key Deadlines:**
+- Tax return: March 31 (extensions available)
+- Tax payment: 30 days from bill
+- Permit renewal: Before expiry
+- Health insurance: 3 months after arrival
+- Rechtsvorschlag: 10 days from Zahlungsbefehl
+- Registration: 8-14 days after moving
+
+**Canton Variations:**
+- Different tax deadlines and forms
+- Varying permit processing times
+- Language requirements differ
+- Municipal procedures vary
+
+### 3. User Advocacy
+
+Represent target users in product decisions:
+
+**Primary Users:**
+1. **New expats** (Maria persona) - First-time navigators, high anxiety
+2. **Refugees** (Ahmed persona) - Language barriers, permit concerns
+3. **Long-term residents** (Thomas) - Bureaucratic German fatigue
+4. **Elderly Swiss** (Rosa) - Complexity overwhelm, scam concerns
+5. **Young adults** (Luca) - First-time adulting
+
+**User Questions to Ask:**
+- "Would Maria understand this?"
+- "Could Ahmed use this with limited French?"
+- "Would this reduce Thomas's decoding time?"
+- "Is this simple enough for Rosa?"
+- "Would Luca find this engaging on mobile?"
+
+### 4. Terminology Accuracy
+
+Ensure Swiss-specific accuracy:
+
+**Language Rules:**
+- Official documents use Hochdeutsch, not Swiss German dialect
+- No ß in Swiss German (use ss)
+- Swiss terms: "innert" (within), "allfällig" (possible)
+- French/Italian equivalents must be accurate
+
+**Abbreviation Standards:**
+| Must Know | Meaning |
+|-----------|---------|
+| AHV/AVS | Old-age insurance |
+| IV/AI | Disability insurance |
+| BVG/LPP | Occupational pension |
+| KVG/LAMal | Health insurance law |
+| SEM | Migration authority |
+| SUVA | Accident insurance |
+
+**Translation Priorities:**
+1. Deadlines - Always extract and highlight
+2. Action items - What must the user do?
+3. Amounts - Preserve CHF formatting
+4. Legal basis - Reference but explain
+5. Appeals info - Rechtsmittelbelehrung sections
+
+### 5. Feature Specification Review
+
+For any proposed feature, verify:
+
+```markdown
+## Domain Expert Review Checklist
+
+### User Value
+- [ ] Addresses documented pain point
+- [ ] Clear benefit to identified persona(s)
+- [ ] Priority justified by user impact
+
+### Swiss Accuracy
+- [ ] Terminology correct (DE/FR/IT)
+- [ ] Canton variations considered
+- [ ] Deadlines accurately represented
+- [ ] Legal context appropriate
+
+### Privacy Compliance
+- [ ] Aligns with nFADP principles
+- [ ] Minimizes data collection
+- [ ] Clear consent where needed
+- [ ] Deletion capability included
+
+### Business Alignment
+- [ ] Supports core value proposition
+- [ ] Differentiates from generic translation
+- [ ] Viable for solo developer scope
+```
+
+## Communication Patterns
+
+### When Asked About Features
+
+**Response Format:**
+```
+## Domain Assessment: [Feature Name]
+
+### User Need (1-5): [Rating]
+[Explanation of user pain point and relevance]
+
+### Swiss Relevance (1-5): [Rating]
+[How this relates to Swiss official correspondence]
+
+### Priority Recommendation: P[0-3]
+[Reasoning based on user impact and business value]
+
+### Considerations
+- [Key Swiss-specific factors]
+- [Potential canton variations]
+- [Privacy implications]
+
+### Recommendation
+[Proceed / Modify / Defer with reasoning]
+```
+
+### When Reviewing Translations/Explanations
+
+**Accuracy Check:**
+1. Is the Swiss term correct?
+2. Is the explanation accurate for Swiss context?
+3. Are there canton-specific variations to note?
+4. Would the target user understand this?
+
+### When Prioritizing Backlog
+
+**Questions to Answer:**
+- What causes the most user anxiety?
+- What prevents costly mistakes?
+- What differentiates from Google Translate?
+- What can be done well by one developer?
+
+## Knowledge References
+
+When providing guidance, reference:
+
+- `.claude/knowledge/SWISS_DOMAIN.md` - Quick domain reference
+- `.claude/knowledge/USER_CONTEXT.md` - User personas & needs
+- `docs/SWISS_TERMINOLOGY_GLOSSARY.md` - Complete terminology
+- `docs/research/swiss-official-correspondence-guide.md` - Document details
+- `docs/research/USER_PERSONAS.md` - Full persona profiles
+- `docs/MARKET_ANALYSIS.md` - Market context
+
+## Collaboration with Other Agents
+
+**Work WITH:**
+- **Planner** - Validate user needs before planning
+- **UX Designer** - Ensure UI serves real user contexts
+- **Architect** - Advise on Swiss-specific requirements
+- **ML Expert** - Guide OCR priorities and accuracy needs
+- **Market Analyst** - Align features with business viability
+
+**Handoff Pattern:**
+```
+User Request → Domain Expert (validate need) → Planner (design solution) →
+Architect + UX Designer (implementation) → Domain Expert (final review)
+```
+
+## Example Interactions
+
+### Example 1: New Feature Request
+
+**Input:** "Should we add support for Swiss voting materials?"
+
+**Domain Expert Response:**
+```
+## Domain Assessment: Voting Materials Support
+
+### User Need: 3/5
+Voting materials are important but:
+- Swiss citizens and long-term C permit holders already read German/French
+- Expats (B/L permits) cannot vote
+- Lower frequency than tax/insurance (4x/year max)
+
+### Swiss Relevance: 4/5
+Genuine Swiss document type, but:
+- Primarily affects Swiss citizens or dual nationals
+- Less relevant for our primary expat audience
+
+### Priority Recommendation: P3
+
+### Considerations
+- Core users (B/L permit expats) cannot vote
+- Focus on documents that affect legal status and finances first
+
+### Recommendation
+Defer. Focus on tax, insurance, and permit documents that our core users receive and must respond to.
+```
+
+### Example 2: Translation Review
+
+**Input:** "Is 'Steuerfuss' translated correctly as 'tax rate'?"
+
+**Domain Expert Response:**
+```
+Partially correct but needs context.
+
+**Steuerfuss** specifically means the municipal tax multiplier applied to the
+cantonal base rate. It's not a general "tax rate."
+
+**Better explanation for users:**
+"The Steuerfuss (tax multiplier) is a percentage set by your municipality.
+It's applied to your base tax amount. For example, a Steuerfuss of 119%
+means you pay 119% of the calculated cantonal rate. Different municipalities
+have different Steuerfuss rates - this affects your total tax bill."
+
+This explanation helps users understand WHY their tax varies by municipality.
+```
+
+### Example 3: Prioritization
+
+**Input:** "Should we prioritize PDF support or multi-page documents?"
+
+**Domain Expert Response:**
+```
+## Prioritization Analysis
+
+### PDF Support
+- Many official documents sent as PDF (increasingly digital)
+- Tax returns often submitted/received as PDF
+- Insurance statements typically PDF
+
+### Multi-page Documents
+- Tax forms are multi-page
+- Rental contracts are lengthy
+- Some permit applications span pages
+
+### User Impact
+Both matter, but PDF support blocks more users since:
+1. Users increasingly receive digital correspondence
+2. Many official portals provide PDF downloads
+3. Users screenshot phone notifications, want to upload PDF originals
+
+### Recommendation: PDF Support First (P1)
+Multi-page can follow as P2, but PDF unlocks the digital correspondence use case that affects all our personas.
+```
+
+## Anti-Patterns
+
+**Avoid:**
+- Generic advice not specific to Switzerland
+- Ignoring canton variations when relevant
+- Assuming all users are tech-savvy expats
+- Overcomplicating for edge cases
+- Forgetting privacy implications
+- Prioritizing features that don't serve core users

--- a/.claude/agents/market-analyst/AGENT.md
+++ b/.claude/agents/market-analyst/AGENT.md
@@ -1,0 +1,383 @@
+---
+name: market-analyst
+description: Business and market strategy analyst. Use this agent for go-to-market decisions, pricing strategy, competitive positioning, and monetization planning.
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+# Market Analyst Agent
+
+## Role
+
+Business strategy specialist responsible for:
+- Market analysis and competitive positioning
+- Pricing and monetization strategy
+- Go-to-market planning
+- Business viability assessment for features
+
+## Mission
+
+Ensure BriefBot is not just useful but also viable as a business, with sustainable monetization aligned with user value and market realities.
+
+## Core Responsibilities
+
+### 1. Market Context
+
+**Target Market Size:**
+- 2.5 million foreign residents (27% of Swiss population)
+- 83,000+ annual new immigrants
+- 78,000+ international students
+- First-generation immigrants: ~3 million
+
+**Market Value:**
+- Professional translation: CHF 0.15-0.50/word
+- Average document translation: CHF 30-60
+- Relocation services: CHF 3,000-15,000
+- BriefBot displaces part of this spend
+
+### 2. Competitive Positioning
+
+**Competitive Landscape:**
+| Competitor | Strength | Weakness for Swiss Docs |
+|------------|----------|-------------------------|
+| Google Translate | Free, instant | No Swiss context |
+| DeepL | Quality | Generic, no doc handling |
+| Professional translators | Accurate | Expensive, slow |
+| Expat forums | Free | Slow, unreliable |
+
+**BriefBot's Position:**
+> "The only instant, affordable, privacy-first solution with Swiss official document expertise."
+
+**Key Differentiators:**
+1. Swiss-specific terminology and context
+2. Document type recognition and deadline extraction
+3. Privacy-first (Swiss nFADP compliant)
+4. Mobile-first for immediate understanding
+
+### 3. Monetization Strategy
+
+**Recommended Model: Freemium**
+
+| Tier | Price | Features |
+|------|-------|----------|
+| Free | CHF 0 | 3 docs/month, basic OCR + translation |
+| Premium | CHF 9.90/month or CHF 79/year | Unlimited, terminology, history, templates |
+| Pro | CHF 19.90/month or CHF 159/year | Family (4 users), calendar, priority support |
+
+**Launch Pricing (Introductory):**
+- Premium: CHF 7.90/month or CHF 59/year
+- Raise after 1,000 paid users
+
+**B2B Opportunities:**
+| Segment | Value Prop | Model |
+|---------|------------|-------|
+| Relocation companies | White-label | CHF 500-2,000/month |
+| HR departments | Onboarding tool | CHF 20/employee/month |
+| Health insurers | Customer aid | Per-policyholder |
+| International schools | Parent communication | Site license |
+
+### 4. Revenue Projections
+
+| Metric | Year 1 | Year 2 | Year 3 |
+|--------|--------|--------|--------|
+| Free users | 10,000 | 35,000 | 80,000 |
+| Premium conversion | 5% | 7% | 10% |
+| Paying users | 500 | 2,450 | 8,000 |
+| B2C Revenue | CHF 39,500 | CHF 208,250 | CHF 760,000 |
+| B2B Revenue | CHF 10,000 | CHF 50,000 | CHF 200,000 |
+| **Total** | CHF 49,500 | CHF 258,250 | CHF 960,000 |
+
+### 5. Go-to-Market Strategy
+
+**Phase 1 (Months 1-6): Community Launch**
+- Target: German-speaking Switzerland expats
+- Channels: r/Switzerland, englishforum.ch, Product Hunt
+- CAC target: < CHF 10 (organic focus)
+
+**Phase 2 (Months 6-12): Expansion**
+- Expand to French/Italian regions
+- B2B pilot with small relocation firms
+- Paid acquisition (Google Ads, Facebook)
+
+**Phase 3 (Year 2+): Scale**
+- Enterprise partnerships (insurers, banks)
+- International expansion (Germany, Austria)
+- API offering for integrations
+
+**Launch Markets (Priority):**
+1. Zurich - Largest expat tech community
+2. Geneva - International organizations
+3. Basel - Pharma industry
+4. Zug - Finance/crypto hub
+
+### 6. Feature-Business Alignment
+
+When evaluating features, assess:
+
+**Revenue Impact:**
+- Does this increase conversion to paid?
+- Does this reduce churn?
+- Does this enable B2B opportunities?
+
+**Cost Impact:**
+- API costs per usage
+- Infrastructure requirements
+- Maintenance burden
+
+**Competitive Moat:**
+- Does this differentiate from free alternatives?
+- Is it defensible against Google/DeepL?
+- Does it deepen Swiss-specific expertise?
+
+## Analysis Frameworks
+
+### Feature Business Case Template
+
+```markdown
+## Business Case: [Feature Name]
+
+### Revenue Impact
+- **Conversion**: Will this convert free → paid?
+- **Retention**: Will this reduce churn?
+- **Expansion**: Enables upsell or B2B?
+
+### Cost Analysis
+- **API costs**: Per-document cost estimate
+- **Development**: One-time vs ongoing
+- **Maintenance**: Complexity burden
+
+### Competitive Impact
+- **Differentiation**: Unique vs commoditized
+- **Defensibility**: Easy to copy?
+- **Market timing**: First mover advantage?
+
+### Recommendation
+[Build / Defer / Investigate] with reasoning
+```
+
+### Pricing Decision Framework
+
+When considering pricing changes:
+
+1. **Value Anchoring**: What does user save vs alternatives?
+2. **Willingness to Pay**: Based on persona income/priorities
+3. **Competitive Pressure**: What do alternatives cost?
+4. **Unit Economics**: Does it cover costs + margin?
+
+**Value Justification:**
+| BriefBot Premium | Alternative Cost |
+|------------------|------------------|
+| CHF 79/year | vs. 2 professional translations (CHF 100-150) |
+| | vs. 1 hour relocation consultant (CHF 280) |
+| | vs. Forum anxiety + time spent (priceless) |
+
+### Market Entry Analysis
+
+For new markets or segments:
+
+```markdown
+## Market Entry: [Segment/Region]
+
+### Market Size
+- TAM: [Total addressable]
+- SAM: [Serviceable]
+- SOM: [Obtainable Year 1]
+
+### Competition
+- Who serves this segment today?
+- What are their weaknesses?
+
+### Entry Strategy
+- Go-to-market approach
+- Required adaptations
+- Investment needed
+
+### Risk Assessment
+- What could go wrong?
+- Mitigation strategies
+```
+
+## Communication Patterns
+
+### When Evaluating Features
+
+**Response Format:**
+```
+## Business Assessment: [Feature]
+
+### Revenue Potential: [Low/Medium/High]
+[Impact on conversion, retention, expansion]
+
+### Cost Consideration: [Low/Medium/High]
+[Development, API, maintenance costs]
+
+### Strategic Fit: [Low/Medium/High]
+[Alignment with positioning, differentiation]
+
+### Recommendation
+[Build now / Defer / Investigate further]
+```
+
+### When Discussing Pricing
+
+**Key Points to Cover:**
+1. Value delivered vs price asked
+2. Competitive comparison
+3. User segment sensitivity
+4. Revenue vs growth tradeoff
+
+### When Assessing Partnerships
+
+**Evaluation Criteria:**
+1. Revenue potential
+2. Brand alignment
+3. Integration complexity
+4. Exclusivity requirements
+5. Long-term strategic value
+
+## Knowledge References
+
+- `docs/MARKET_ANALYSIS.md` - Full market research
+- `.claude/knowledge/USER_CONTEXT.md` - User personas
+- `docs/research/USER_PERSONAS.md` - Detailed persona economics
+
+## Collaboration with Other Agents
+
+**Work WITH:**
+- **Domain Expert** - Validate user need before business case
+- **Planner** - Align features with business goals
+- **Architect** - Understand cost implications
+- **Infra** - Assess scalability costs
+
+**Handoff Pattern:**
+```
+Domain Expert (user need) → Market Analyst (business case) →
+Planner (if approved) → Implementation
+```
+
+## Example Interactions
+
+### Example 1: Feature Investment Decision
+
+**Input:** "Should we invest in a browser extension?"
+
+**Response:**
+```
+## Business Assessment: Browser Extension
+
+### Revenue Potential: Medium
+- Could increase engagement (easy access)
+- May improve free→paid conversion
+- Limited B2B applicability
+
+### Cost Consideration: Medium
+- New codebase to maintain
+- Chrome + Firefox minimum
+- Ongoing compatibility updates
+
+### Strategic Fit: Medium
+- Differentiates from mobile-only competitors
+- Reaches users at their desktop (email PDFs)
+- But core users are mobile-first
+
+### Recommendation: Defer to Year 2
+Focus on mobile experience first. Desktop users can use web app.
+Browser extension makes sense after:
+1. Mobile app is mature
+2. User research confirms desktop demand
+3. Resources allow parallel development
+```
+
+### Example 2: Pricing Question
+
+**Input:** "Should we offer a student discount?"
+
+**Response:**
+```
+## Pricing Analysis: Student Discount
+
+### Market Size
+- 78,000+ international students
+- High document volume (permits, insurance, registration)
+- Low income, high price sensitivity
+
+### Recommendation: Yes, 50% discount
+
+### Rationale
+1. **Acquisition**: Students are influencers, recommend to friends
+2. **Lifetime value**: Graduate → employed → full price
+3. **Competition**: Prevents free alternatives from capturing segment
+4. **Cost**: Low marginal cost to serve
+
+### Implementation
+- CHF 39/year (50% off annual)
+- Require .edu email or student ID verification
+- Auto-convert to full price after 4 years
+
+### Projected Impact
+- +2,000 student users Year 1
+- +CHF 78,000 revenue
+- +Word of mouth acquisition
+```
+
+### Example 3: Partnership Evaluation
+
+**Input:** "A health insurer wants to integrate BriefBot for policyholders."
+
+**Response:**
+```
+## Partnership Assessment: Health Insurer Integration
+
+### Opportunity
+- Access to large policyholder base
+- Reduces their support calls
+- Recurring B2B revenue
+
+### Evaluation
+
+**Revenue**: High
+- Per-policyholder fee model (CHF 0.50-1/month)
+- 100K policyholders = CHF 50-100K/year
+
+**Brand**: Positive
+- Association with trusted Swiss institution
+- Validation of our value proposition
+
+**Integration**: Medium complexity
+- API integration with their portal
+- Custom branding/white-label
+- Data handling agreements
+
+**Risks**
+- Exclusivity demands (avoid)
+- Data ownership clarity needed
+- Support burden if issues
+
+### Recommendation: Pursue with conditions
+1. Non-exclusive (can work with other insurers)
+2. Clear data boundaries (nFADP compliant)
+3. Minimum guarantee or pilot period
+4. Our brand visible ("powered by BriefBot")
+```
+
+## Success Metrics
+
+Track business health via:
+
+| Metric | Target |
+|--------|--------|
+| Free→Premium conversion | 5-10% |
+| Monthly churn | <5% |
+| CAC (paid channels) | <CHF 50 |
+| LTV:CAC ratio | >3:1 |
+| NPS | >40 |
+
+## Anti-Patterns
+
+**Avoid:**
+- Underpricing that signals low value
+- Overcomplicating tier structure
+- Ignoring unit economics (API costs)
+- Chasing B2B before proving B2C
+- Feature creep without business case
+- Exclusivity deals that limit growth

--- a/.claude/knowledge/SWISS_DOMAIN.md
+++ b/.claude/knowledge/SWISS_DOMAIN.md
@@ -1,0 +1,99 @@
+# Swiss Domain Knowledge Reference
+
+> Quick reference for agents working on BriefBot features related to Swiss official correspondence.
+
+## Key Document Categories
+
+### 1. Tax Documents (Steuern)
+- **Steuererklärung** - Tax return (annual, due ~March 31)
+- **Steuerrechnung** - Tax bill (after assessment)
+- **Veranlagungsverfügung** - Assessment notice
+- **Quellensteuer** - Withholding tax (for B/L permits)
+
+### 2. Health Insurance (Krankenversicherung)
+- **Grundversicherung** - Mandatory basic insurance (KVG/LAMal)
+- **Franchise** - Deductible (CHF 300-2,500)
+- **Selbstbehalt** - Co-payment (10% after franchise)
+- Must enroll within 3 months of arrival
+
+### 3. Immigration Permits
+| Permit | Name | Duration |
+|--------|------|----------|
+| L | Short-term | <1 year |
+| B | Residence | 5 years (EU) |
+| C | Settlement | Permanent |
+| G | Cross-border | 5 years |
+| F | Provisionally admitted | Temporary |
+
+### 4. Social Security (3-Pillar System)
+- **Pillar 1 (AHV/AVS)** - State pension (mandatory)
+- **Pillar 2 (BVG/LPP)** - Occupational pension (mandatory if employed)
+- **Pillar 3a** - Private pension (tax-advantaged)
+
+### 5. Debt Collection (Betreibung)
+- **Zahlungsbefehl** - Payment order
+- **Rechtsvorschlag** - Objection (10 days to file)
+- **Pfändung** - Asset seizure
+- Public record visible for 5 years
+
+## Common Abbreviations
+
+| Abbrev | German | English |
+|--------|--------|---------|
+| AHV | Alters- und Hinterlassenenversicherung | Old-age insurance |
+| IV | Invalidenversicherung | Disability insurance |
+| BVG | Berufliche Vorsorge | Occupational pension |
+| KVG | Krankenversicherungsgesetz | Health insurance law |
+| ALV | Arbeitslosenversicherung | Unemployment insurance |
+| SUVA | Schweizerische Unfallversicherungsanstalt | Accident insurance |
+| SEM | Staatssekretariat für Migration | Migration authority |
+
+## Key Deadlines
+
+| Document | Typical Deadline | Consequence |
+|----------|------------------|-------------|
+| Tax return | March 31 | Discretionary assessment |
+| Tax payment | 30 days | 4-5% interest |
+| Health insurance | 3 months after arrival | Retroactive premiums |
+| Registration | 14 days | Fine CHF 100+ |
+| Permit renewal | Before expiry | Status gap |
+| Rechtsvorschlag | 10 days | Enforcement proceeds |
+
+## Swiss Government Structure
+
+- **Federal (Bund)**: ESTV (tax), SEM (migration), BSV (social insurance)
+- **Cantonal (Kanton)**: Tax offices, migration offices, IV offices
+- **Municipal (Gemeinde)**: Registration, civil registry
+
+## Language Considerations
+
+- **Official documents**: Written in Hochdeutsch (Standard German), not Swiss German dialect
+- **4 languages**: German (62%), French (23%), Italian (8%), Romansh (<1%)
+- **26 cantons**: Each with own procedures and some terminology variations
+- **Key Swiss terms**: "innert" (within), "allfällig" (possible), no ß (use ss)
+
+## Privacy Requirements (nFADP)
+
+- Privacy by Design mandatory
+- Opt-in consent required
+- Max fine: CHF 250,000 (personal liability)
+- Right to deletion
+- Data minimization principle
+
+## Document Structure
+
+Typical Swiss official letter contains:
+1. Sender header with reference number
+2. Subject line (Betreff)
+3. Legal basis citations
+4. Deadline (prominently displayed)
+5. QR-bill payment section
+6. Rechtsmittelbelehrung (appeals info)
+
+## For More Details
+
+See research documents:
+- `docs/SWISS_TERMINOLOGY_GLOSSARY.md` - Complete terminology
+- `docs/research/swiss-official-correspondence-guide.md` - Document types & institutions
+- `docs/research/USER_PERSONAS.md` - User pain points & journeys
+- `docs/MARKET_ANALYSIS.md` - Market context & positioning

--- a/.claude/knowledge/USER_CONTEXT.md
+++ b/.claude/knowledge/USER_CONTEXT.md
@@ -1,0 +1,106 @@
+# User Context Reference
+
+> Quick reference for understanding BriefBot's target users and their needs.
+
+## Target Market
+
+- **2.5 million** foreign residents in Switzerland (27% of population)
+- **83,000+** new immigrants annually
+- **78,000+** international students
+- No existing solution specifically for Swiss official documents
+
+## Primary User Personas
+
+### 1. Maria - New Expat (Primary)
+- Brazilian software engineer, 3 months in Zurich
+- B permit holder, high tech comfort
+- **Pain**: First tax return, health insurance choices, permit requirements
+- **Needs**: Instant understanding, deadline alerts, Swiss context
+
+### 2. Ahmed - Refugee
+- Syrian with F permit in Geneva
+- Limited French, high anxiety about permit
+- **Pain**: Integration requirements, fear of mistakes affecting status
+- **Needs**: Simple language, visual cues, reassurance
+
+### 3. Thomas - Long-term Resident
+- British, 15 years in Bern, C permit
+- Speaks German but struggles with "Amtsdeutsch"
+- **Pain**: Bureaucratic German, time wasted decoding letters
+- **Needs**: Quick summaries, jargon explanation
+
+### 4. Rosa - Elderly Swiss
+- Italian-speaking Swiss in Zurich, 74 years old
+- Low tech comfort, overwhelmed by modern complexity
+- **Pain**: Scam detection, health insurance changes
+- **Needs**: Large text, simple interface, trust indicators
+
+### 5. Luca - Young Adult
+- Swiss student, first time managing own bureaucracy
+- Very high tech comfort, prefers mobile
+- **Pain**: No education on adulting, canton change
+- **Needs**: Visual explanations, shareable content
+
+## Core Pain Points (All Users)
+
+| Pain Point | Severity | Opportunity |
+|------------|----------|-------------|
+| Unknown deadlines | Critical | Deadline extraction |
+| Bureaucratic jargon | High | Plain language summaries |
+| Fear of mistakes | High | Confidence indicators |
+| Action items unclear | High | Action extraction |
+| Canton-specific rules | Medium | Canton-aware context |
+| Scam vs. real confusion | Medium | Document verification |
+
+## Emotional Journey
+
+```
+Letter arrives → Anxiety ("What now?") → Translation attempt →
+Confusion → Help-seeking → Delayed action → Relief or Panic
+```
+
+## What Users Want
+
+1. **Instant OCR** - Answers now, not in 24 hours
+2. **Deadline extraction** - #1 anxiety reducer
+3. **Action items** - "What do I need to do?"
+4. **Plain language** - "What this means"
+5. **Canton-aware** - Rules vary by location
+6. **Privacy-first** - Sensitive documents
+
+## Current Alternatives (Pain Points)
+
+| Alternative | Problem |
+|-------------|---------|
+| Google Translate | No Swiss context, often wrong |
+| Professional translation | CHF 30-60/document, 2-5 days |
+| Expat forums | Slow, unreliable |
+| Friends/colleagues | Privacy concerns, availability |
+
+## Success Metrics
+
+| Metric | Target |
+|--------|--------|
+| Time to understanding | < 60 seconds |
+| User confidence ("I understand") | > 4/5 |
+| Deadline identification | > 95% accuracy |
+| Return usage (30 days) | > 40% |
+
+## Key Quotes
+
+> "I'm a senior engineer who manages complex systems, but Swiss bureaucracy makes me feel incompetent." - Maria
+
+> "I don't know what I don't know. Each letter might be routine or life-changing." - Ahmed
+
+> "Fifteen years here and I still can't decode an official letter quickly." - Thomas
+
+## Design Implications
+
+- **Mobile-first**: Most users photograph letters immediately
+- **Calm UI**: Reduce anxiety, avoid alarming colors
+- **Trust signals**: Privacy emphasis, accuracy indicators
+- **Education**: Help users learn, not just translate
+
+## For More Details
+
+See `docs/research/USER_PERSONAS.md` for complete persona profiles and journey maps.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,18 @@ Invoke these for specific tasks:
 ### Agents (`.claude/agents/`)
 Specialized subagents with focused system prompts:
 
+**domain-expert** - Swiss domain expertise & product owner ⭐ VALIDATE NEEDS FIRST
+- Swiss official correspondence knowledge
+- User need validation
+- Feature prioritization
+- Terminology accuracy
+
+**market-analyst** - Business & market strategy
+- Go-to-market decisions
+- Pricing and monetization
+- Competitive positioning
+- Business viability assessment
+
 **planner** - Planning methodology
 - User-centered design thinking
 - Swiss context considerations
@@ -107,6 +119,7 @@ Specialized subagents with focused system prompts:
 BriefBot/
 ├── .claude/
 │   ├── agents/              # Specialized subagents (planner, architect, etc.)
+│   ├── knowledge/           # Domain knowledge for agents
 │   └── skills/              # Invokable skills (plan, review)
 ├── app/                     # Next.js 15 App Router
 │   ├── (auth)/              # Authentication routes
@@ -133,6 +146,7 @@ BriefBot/
 ├── docs/
 │   ├── specs/               # Feature specifications
 │   ├── screenshots/         # Screenshot documentation
+│   ├── research/            # User research & market analysis
 │   ├── ADR/                 # Architecture Decision Records
 │   ├── COMPLIANCE/          # nFADP compliance docs
 │   ├── SECURITY/            # Security documentation
@@ -275,25 +289,28 @@ npm run type-check         # TypeScript check
 
 | Task | Primary Agent | Also Consider |
 |------|---------------|---------------|
-| Plan new feature | `planner` | - |
+| Validate user need / feature priority | `domain-expert` | `market-analyst` |
+| Business viability / pricing | `market-analyst` | `domain-expert` |
+| Plan new feature | `planner` | `domain-expert` |
 | Design system architecture | `architect` | `security` |
 | Build UI component | `ux-designer` | `tester` |
 | Database schema change | `persistence` | `security` |
 | Security/privacy review | `security` | - |
 | Write tests | `tester` | - |
 | Code review | `reviewer` | - |
-| OCR/translation feature | `ml-expert` | `architect` |
+| OCR/translation feature | `ml-expert` | `architect`, `domain-expert` |
 | Docker/CI/CD setup | `infra` | - |
 
 ### Core Workflow (Daily Use)
 
 ```
-1. /plan or planner    → Define what to build
-2. architect + ux-designer (parallel) → Design solution
-3. Implement with TDD
-4. reviewer or /review → Validate before commit
-5. npm run pre-pr      → Local validation
-6. gh pr create        → Create PR
+1. domain-expert       → Validate user need & priority
+2. /plan or planner    → Define what to build
+3. architect + ux-designer (parallel) → Design solution
+4. Implement with TDD
+5. reviewer or /review → Validate before commit
+6. npm run pre-pr      → Local validation
+7. gh pr create        → Create PR
 ```
 
 ### When to Spawn Multiple Agents (Parallel)

--- a/docs/MARKET_ANALYSIS.md
+++ b/docs/MARKET_ANALYSIS.md
@@ -1,0 +1,556 @@
+# BriefBot Market Analysis
+
+## Executive Summary
+
+BriefBot targets a substantial and growing market of 2.5+ million foreign residents in Switzerland who face significant challenges with official correspondence in German, French, and Italian. The combination of complex multilingual bureaucracy, high professional translation costs (CHF 0.15-0.50/word), and gaps in existing solutions creates a compelling opportunity for a privacy-first, mobile OCR/translation app specifically designed for Swiss official documents.
+
+**Key Opportunity Indicators:**
+- 27% of Swiss population (2.5M people) are foreign nationals
+- 41% have migration background, 80% first-generation immigrants
+- 83,000+ new immigrants annually
+- 78,000+ international students
+- Professional translation costs: CHF 0.15-0.50 per word (CHF 1.90-4.50 per line)
+- No existing solution specifically addresses Swiss official document translation
+
+---
+
+## 1. Market Size Analysis
+
+### 1.1 Target Demographics
+
+#### Primary Market: Foreign Residents
+| Segment | Population | Key Characteristics |
+|---------|------------|---------------------|
+| Permanent foreign residents | 2.5 million | 27% of total population |
+| Migration background | 3.7 million | 41% of population |
+| First-generation immigrants | ~3 million | 80% of migration background |
+| Annual new immigrants | 83,000+ | 93% of population growth |
+
+**Source:** [Federal Statistical Office](https://www.bfs.admin.ch/bfs/en/home/statistics/population/migration-integration/foreign/composition.html), [SWI swissinfo.ch](https://www.swissinfo.ch/eng/demographics/41-per-cent-of-people-in-switzerland-have-a-migration-background/90138181)
+
+#### Secondary Markets
+| Segment | Size | Notes |
+|---------|------|-------|
+| International students | 78,000+ | Record enrollment in 2024/25 |
+| Third-country work permits | 8,500/year | Quota for specialists |
+| UK nationals (post-Brexit) | 3,500/year | Dedicated quota |
+| Ukrainian refugees (Status S) | ~80,000 | Extended until March 2026 |
+
+**Source:** [OECD Migration Outlook 2025](https://www.oecd.org/en/publications/2025/11/international-migration-outlook-2025_355ae9fd/full-report/switzerland_d6b0d504.html), [Erudera](https://erudera.com/news/record-78000-international-students-are-studying-in-switzerland-this-academic-year/)
+
+#### Geographic Distribution by Language Region
+| Region | Main Language | % of Foreign Residents |
+|--------|---------------|------------------------|
+| German-speaking | German/Swiss German | ~60% |
+| French-speaking | French | ~30% |
+| Italian-speaking | Italian | ~8% |
+| Romansh-speaking | Romansh | ~2% |
+
+#### Top Nationalities (Non-German/French/Italian speakers at risk)
+1. Italian - 14.7% (may need German/French help)
+2. German - 14.0% (may need French/Italian help)
+3. Portuguese - 11.7% (need all Swiss languages)
+4. France - 6.6% (may need German/Italian help)
+5. Other European - 37%
+6. Non-European - 17%
+
+### 1.2 Total Addressable Market (TAM) Estimation
+
+**Conservative calculation:**
+- Total foreign residents: 2,500,000
+- Percentage who struggle with official documents: 50% (1,250,000)
+- Average documents per year requiring translation: 12 (tax, insurance, permits, utilities)
+- Potential individual transactions per year: 15,000,000
+
+**Market Value (based on professional translation displacement):**
+- Average document: 250 words
+- Professional cost: CHF 0.25/word average = CHF 62.50/document
+- Total professional translation market displaced: CHF 937 million/year
+
+**Realistic Serviceable Market:**
+- Penetration target Year 1: 1% = 12,500 users
+- Penetration target Year 3: 5% = 62,500 users
+- Penetration target Year 5: 10% = 125,000 users
+
+---
+
+## 2. Competitive Landscape
+
+### 2.1 Direct Competitors
+
+#### General Translation Apps
+| Solution | Strengths | Weaknesses for Swiss Documents |
+|----------|-----------|-------------------------------|
+| **Google Translate** | Free, camera mode, 100+ languages, offline packs | No Swiss document context, formatting issues with PDFs, privacy concerns |
+| **DeepL** | Superior European language quality, PDF support, built-in OCR | No Swiss-specific terminology, generic translations, subscription for volume |
+| **Apple Translate** | Native iOS integration, offline | Limited language pairs, no OCR |
+| **Microsoft Translator** | Enterprise integration | No specialized document handling |
+
+**Key Gap:** None of these understand Swiss official terminology (Gemeinde, Quellensteuer, AHV/AVS, etc.) or provide context for Swiss bureaucratic processes.
+
+**Source:** [DeepL Pro](https://www.deepl.com/en/pro), [Taia Comparison](https://taia.io/blog/technology-and-translation/deepl-vs-google-translate-vs-taia-best-ai-file-translators-compared/)
+
+#### OCR-Specific Solutions
+| Solution | Strengths | Weaknesses |
+|----------|-----------|------------|
+| **Adobe Scan** | Professional OCR quality | No integrated translation |
+| **CamScanner** | Popular mobile scanner | Privacy concerns, Chinese company |
+| **ABBYY FineReader** | Enterprise-grade OCR | Expensive, not mobile-first |
+
+### 2.2 Indirect Competitors
+
+#### Professional Translation Services
+| Service Type | Typical Cost | Turnaround |
+|--------------|--------------|------------|
+| Certified translation | CHF 0.25-0.50/word | 2-5 days |
+| Standard translation | CHF 0.15-0.35/word | 1-3 days |
+| Express translation | +50-100% surcharge | Same day |
+| Minimum order | CHF 50-200 | - |
+
+**Source:** [SwissGlobal](https://swissglobal.ch/en/blog/how-much-does-a-translation-cost/), [UniTranslate](https://www.unitranslate.ch/en/kosten-beglaubigte-uebersetzung)
+
+**Key Insight:** A single-page official letter costs CHF 30-60 to professionally translate. BriefBot could provide instant understanding for a fraction of this cost.
+
+#### Relocation Services
+| Service Level | Cost | Includes Translation |
+|---------------|------|---------------------|
+| Basic package | CHF 3,000-5,000 | Limited |
+| Full service | CHF 8,000-15,000+ | Often included |
+| Hourly consulting | CHF 280/hour | Case by case |
+
+**Source:** [Swiss Relocation Services](https://swiss-relocation.ch/en/prices/)
+
+**Key Insight:** Most expats cannot afford relocation services. BriefBot fills the gap for DIY settlers.
+
+#### Community Resources
+| Resource | Strengths | Limitations |
+|----------|-----------|-------------|
+| English Forum Switzerland | 60,000+ members, free advice | Slow response, not always accurate |
+| Expat.com Switzerland | Active community | General, not document-specific |
+| Swiss Ready | Document help service | Manual, paid per document |
+| ch.ch (government) | Official information | Not personalized, complex |
+
+**Source:** [English Forum Switzerland](https://www.englishforum.ch/), [Swiss Ready](https://www.swiss-ready.com/our-services/translation-documents)
+
+### 2.3 Competitive Positioning Matrix
+
+```
+                    Swiss-Specific Knowledge
+                    Low                 High
+                    │                    │
+Instant/      ┌─────┼────────────────────┼─────┐
+Low Cost      │     │  Google/DeepL      │ BRIEFBOT │
+              │     │  (gaps in context) │ (target) │
+              ├─────┼────────────────────┼─────┤
+Slow/         │     │  General forums    │ Professional │
+High Cost     │     │                    │ translators │
+              └─────┼────────────────────┼─────┘
+                    │                    │
+```
+
+**BriefBot's Unique Position:** The only solution combining instant mobile access with Swiss-specific document understanding.
+
+---
+
+## 3. User Pain Points
+
+### 3.1 Documented Challenges
+
+Based on expat forums, surveys, and studies:
+
+1. **Official Mail Anxiety**
+   - Receiving German/French letters without understanding urgency
+   - Fear of missing deadlines (tax, permits, insurance)
+   - Uncertainty about required actions
+
+2. **Language Barrier Statistics**
+   - 6-7% of healthcare patients cannot communicate in any Swiss language
+   - 51% of medical services report 1-5% allophone patients
+   - One-third of medical services report "significantly difficult" communication
+
+   **Source:** [PMC Study](https://pmc.ncbi.nlm.nih.gov/articles/PMC6598246/), [PubMed](https://pubmed.ncbi.nlm.nih.gov/20175006/)
+
+3. **Bureaucratic Complexity**
+   - Multiple cantonal systems with different procedures
+   - Documents in official languages only (no English)
+   - Strict deadlines with financial penalties
+   - Language requirements for permits becoming stricter since 2020
+
+   **Source:** [Fragomen](https://www.fragomen.com/insights/language-requirements-to-be-made-stricter-in-2020.html)
+
+4. **Common Document Types Causing Issues**
+   - Tax declarations and assessment notices
+   - Health insurance correspondence
+   - Rental contracts and landlord notices
+   - Permit applications and renewals
+   - School communications for parents
+   - Utility bills and municipal fees
+
+### 3.2 User Quotes (from forums and articles)
+
+> "The initial impression was of flawless order, incredible punctuality, and a logical explanation for everything. But this perfection also meant a high barrier."
+
+> "Expats who did not receive their education in Switzerland struggle to give their children full support in their school lives... checking German homework, understanding long school letters, and following the academic language used by the teacher in parent meetings was very difficult."
+
+> "Simple tasks like reading official documents or chatting with neighbors can become difficult, and this language complexity can also hinder deeper cultural immersion or limit professional opportunities."
+
+**Source:** [FocusSwiss](https://www.focusswiss.com/en/switzerland-first-month-7-difficulties/), [Valentina Chigliaro](https://www.valentinachigliaro.com/articles/being-an-expat-in-switzerland)
+
+---
+
+## 4. Value Proposition
+
+### 4.1 Core Value Drivers
+
+| Driver | User Benefit | Quantifiable Value |
+|--------|--------------|-------------------|
+| **Time Savings** | Instant vs. 2-5 day professional translation | 99% time reduction |
+| **Cost Savings** | CHF 5/month vs. CHF 50+/document | Up to 90% cost reduction |
+| **Anxiety Reduction** | Understand urgency immediately | Priceless for peace of mind |
+| **Privacy** | Local processing, Swiss data protection | Compliance with nFADP |
+| **Context** | Swiss-specific terminology explained | Prevents costly mistakes |
+| **Accessibility** | Mobile-first, available 24/7 | No appointment needed |
+
+### 4.2 Privacy Differentiator
+
+BriefBot's privacy-first approach aligns with Swiss values and regulations:
+
+- **Swiss nFADP Compliance:** New data protection law since September 2023
+- **Local Processing:** Option to process on-device without cloud upload
+- **No Data Retention:** Documents not stored after translation
+- **Transparency:** Clear information about data usage
+- **User Control:** Right to deletion, data portability
+
+**Source:** [Swiss Federal Government](https://www.kmu.admin.ch/kmu/en/home/facts-and-trends/digitization/data-protection/new-federal-act-on-data-protection-nfadp.html), [CookieYes](https://www.cookieyes.com/blog/switzerland-fadp/)
+
+**Key nFADP Requirements:**
+- Privacy by Design and Default mandatory
+- Opt-in consent required
+- Maximum fines: CHF 250,000 (personal liability for directors)
+- Applies to any app processing Swiss residents' data
+
+### 4.3 Unique Features Roadmap
+
+1. **Swiss Terminology Database**
+   - Official term explanations (AHV, BVG, Quellensteuer, etc.)
+   - Canton-specific variations
+   - Links to official resources
+
+2. **Document Type Recognition**
+   - Auto-detect: tax, insurance, permit, utility, etc.
+   - Highlight action items and deadlines
+   - Extract key dates and amounts
+
+3. **Response Templates**
+   - Pre-written Swiss-appropriate responses
+   - Formal German/French letter formats
+   - Deadline request templates
+
+---
+
+## 5. Monetization Strategy
+
+### 5.1 Recommended Model: Freemium with Subscription
+
+Based on successful SaaS translation models:
+
+#### Free Tier
+- 3 documents/month
+- Basic OCR + translation
+- No document storage
+- Standard processing speed
+- Watermarked exports
+
+#### Premium Tier (CHF 9.90/month or CHF 79/year)
+- Unlimited documents
+- Priority processing
+- Swiss terminology explanations
+- Document history (encrypted)
+- Response templates
+- PDF export without watermark
+- Email support
+
+#### Pro Tier (CHF 19.90/month or CHF 159/year)
+- Everything in Premium
+- Multi-language household (up to 4 family members)
+- Calendar integration for deadlines
+- Urgent document alerts
+- Priority support
+- API access for power users
+
+### 5.2 Alternative Revenue Streams
+
+#### B2B Opportunities
+
+| Segment | Value Proposition | Pricing Model |
+|---------|-------------------|---------------|
+| **Relocation Companies** | White-label document understanding | CHF 500-2,000/month + per-document |
+| **HR Departments** | Employee onboarding support | CHF 20/employee/month |
+| **Language Schools** | Learning tool integration | Revenue share |
+| **Health Insurers** | Customer communication aid | Per-policyholder fee |
+| **Banks (expat-focused)** | Value-add for international clients | Partnership/sponsorship |
+| **International Schools** | Parent communication tool | Site license |
+
+**Source:** [Stepes HR Translation](https://www.stepes.com/human-resource-translation-services/)
+
+#### Partnership Opportunities
+
+1. **Health Insurance Integration**
+   - Swiss health insurers (CSS, Helsana, Swica) serve many expats
+   - Offer BriefBot as policyholder benefit
+   - Reduces support calls, improves customer satisfaction
+
+2. **Banking Partnerships**
+   - Banks targeting expats (UBS, Credit Suisse, PostFinance)
+   - Include in premium banking packages
+   - Co-marketing opportunities
+
+3. **Employer Sponsorship**
+   - Multinational companies in Switzerland
+   - Part of relocation package benefits
+   - Bulk licensing
+
+### 5.3 Pricing Justification
+
+| Comparison | BriefBot Premium | Alternative Cost |
+|------------|------------------|------------------|
+| Annual subscription | CHF 79 | - |
+| vs. 2 professional translations | - | CHF 100-150 |
+| vs. 1 hour relocation consultant | - | CHF 280 |
+| vs. Forum anxiety + time spent | - | Priceless |
+
+**Break-even:** User saves money after avoiding just one professional translation.
+
+### 5.4 Revenue Projections
+
+| Metric | Year 1 | Year 2 | Year 3 |
+|--------|--------|--------|--------|
+| Free users | 10,000 | 35,000 | 80,000 |
+| Premium conversion | 5% | 7% | 10% |
+| Paying users | 500 | 2,450 | 8,000 |
+| ARPU (annual) | CHF 79 | CHF 85 | CHF 95 |
+| B2C Revenue | CHF 39,500 | CHF 208,250 | CHF 760,000 |
+| B2B Revenue | CHF 10,000 | CHF 50,000 | CHF 200,000 |
+| **Total Revenue** | **CHF 49,500** | **CHF 258,250** | **CHF 960,000** |
+
+---
+
+## 6. Risks and Mitigation
+
+### 6.1 Legal and Liability Risks
+
+#### Translation Accuracy Liability
+
+**Risk:** Users make decisions based on mistranslations, leading to financial loss or legal issues.
+
+**Mitigation:**
+1. **Clear Disclaimers**
+   - "For understanding purposes only, not legal/official translation"
+   - Recommend professional translation for legal documents
+   - Terms of service limiting liability
+
+2. **Confidence Indicators**
+   - Show translation confidence scores
+   - Flag uncertain translations
+   - Highlight critical terms that may need verification
+
+3. **Insurance**
+   - Professional indemnity insurance (starting ~CHF 100-200/month)
+   - Covers legal defense costs and settlements
+   - Industry standard for translation services
+
+**Source:** [Suited Insurance](https://www.suited.insure/business-insurance/translator-insurance), [Hiscox](https://www.hiscox.com/small-business-insurance/professional-business-insurance/interpreters-and-translators-insurance)
+
+#### Data Protection Compliance
+
+**Risk:** Non-compliance with Swiss nFADP or GDPR (for EU users).
+
+**Mitigation:**
+1. Privacy by Design from day one
+2. Local processing option
+3. Clear consent flows
+4. Data minimization
+5. Regular compliance audits
+
+**Maximum Penalty:** CHF 250,000 (personal liability)
+
+### 6.2 Competitive Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Google adds Swiss context | Medium | High | Build deep Swiss expertise, community |
+| DeepL releases document app | Medium | High | Focus on official document niche |
+| Free alternatives improve | High | Medium | Emphasize privacy + Swiss focus |
+| New Swiss-specific competitor | Low | Medium | First-mover advantage, network effects |
+
+### 6.3 Operational Risks
+
+| Risk | Mitigation |
+|------|------------|
+| AI model accuracy | Continuous training on Swiss documents, user feedback loop |
+| Scaling costs | Efficient model selection, caching, batch processing |
+| Single developer dependency | Comprehensive documentation, automated testing |
+| User acquisition cost | Organic growth via SEO, community partnerships |
+
+### 6.4 Market Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Economic downturn reduces immigration | Medium | Also serves existing residents, B2B pivot |
+| Swiss language requirements relaxed | Low | Unlikely due to political trends |
+| AI translation becomes commodity | High | Differentiate on UX, Swiss context, trust |
+
+---
+
+## 7. Go-to-Market Strategy
+
+### 7.1 Launch Markets (Priority Order)
+
+1. **Zurich** - Largest expat population, English-speaking tech community
+2. **Geneva** - International organizations, French/English speakers
+3. **Basel** - Pharma industry, German/English speakers
+4. **Zug** - Crypto/finance hub, international workforce
+
+### 7.2 Acquisition Channels
+
+#### Organic/Low-Cost
+| Channel | Approach | Expected CAC |
+|---------|----------|--------------|
+| SEO | "Swiss official letter translation", "German letter help" | CHF 0 |
+| Reddit/Forums | Helpful presence in r/Switzerland, englishforum.ch | CHF 0 |
+| Product Hunt | Launch campaign | CHF 0 |
+| App Store Optimization | Keywords, reviews | CHF 0 |
+
+#### Paid
+| Channel | Approach | Expected CAC |
+|---------|----------|--------------|
+| Google Ads | "Translate German letter Switzerland" | CHF 20-40 |
+| Facebook/Instagram | Expat community targeting | CHF 15-30 |
+| LinkedIn | HR and relocation professionals | CHF 30-50 |
+
+### 7.3 Partnership Development
+
+**Phase 1 (Months 1-6):** Community presence
+- Active participation in expat forums
+- Free tier attracts early adopters
+- Gather testimonials
+
+**Phase 2 (Months 6-12):** B2B outreach
+- Approach smaller relocation companies
+- Pilot with HR departments
+- Language school partnerships
+
+**Phase 3 (Year 2+):** Enterprise partnerships
+- Health insurer integration
+- Banking partnerships
+- Corporate licensing
+
+---
+
+## 8. Recommendations
+
+### 8.1 Strategic Positioning
+
+**Position BriefBot as:**
+> "The Swiss expat's personal document assistant - instant understanding of official mail, built with Swiss privacy standards."
+
+**Key Messages:**
+1. **Instant clarity:** Understand any Swiss letter in seconds
+2. **Privacy-first:** Your documents stay yours (Swiss data protection)
+3. **Swiss expertise:** Built for Swiss bureaucracy, not generic translation
+4. **Affordable:** Less than one coffee per week
+
+### 8.2 Product Priorities
+
+1. **MVP Focus:** Core OCR + translation with Swiss terminology
+2. **Differentiation:** Swiss-specific context and explanations
+3. **Trust:** Privacy, accuracy indicators, professional disclaimers
+4. **Retention:** Document history, deadline tracking
+
+### 8.3 Pricing Recommendation
+
+**Launch pricing:**
+- Free: 3 docs/month (generous to drive adoption)
+- Premium: CHF 7.90/month or CHF 59/year (introductory)
+- Raise to CHF 9.90/79 after reaching 1,000 paid users
+
+**Rationale:** Lower initial price reduces friction, builds user base, allows price increase later with proven value.
+
+### 8.4 Success Metrics
+
+| Metric | Year 1 Target | Year 3 Target |
+|--------|---------------|---------------|
+| Monthly Active Users | 5,000 | 50,000 |
+| Premium Conversion | 5% | 10% |
+| Net Promoter Score | >40 | >50 |
+| Churn (monthly) | <8% | <5% |
+| Documents processed | 50,000 | 500,000 |
+
+---
+
+## 9. Conclusion
+
+BriefBot addresses a genuine, underserved need in a substantial market. The combination of:
+- **Large target market** (2.5M foreign residents + annual inflow)
+- **Clear pain points** (language barriers with official documents)
+- **High existing costs** (CHF 30-60+ per document professional translation)
+- **Privacy differentiator** (Swiss data protection alignment)
+- **No direct competition** (Swiss-specific document focus)
+
+...creates a compelling opportunity for a focused, privacy-first solution.
+
+**Recommended approach:**
+1. Launch MVP targeting German-speaking Switzerland expats
+2. Build community presence and organic growth
+3. Expand to French/Italian regions
+4. Develop B2B partnerships for sustainable revenue
+5. Maintain privacy-first positioning as core differentiator
+
+**Estimated market opportunity:**
+- Conservative Year 3 revenue: CHF 500K-1M
+- Optimistic Year 5 revenue: CHF 2-5M
+
+The key to success will be building trust through accuracy, privacy, and genuine Swiss document expertise that generic translation tools cannot match.
+
+---
+
+## Sources
+
+### Demographics and Immigration
+- [Federal Statistical Office - Foreign Population Composition](https://www.bfs.admin.ch/bfs/en/home/statistics/population/migration-integration/foreign/composition.html)
+- [SWI swissinfo.ch - Migration Background Statistics](https://www.swissinfo.ch/eng/demographics/41-per-cent-of-people-in-switzerland-have-a-migration-background/90138181)
+- [OECD International Migration Outlook 2025 - Switzerland](https://www.oecd.org/en/publications/2025/11/international-migration-outlook-2025_355ae9fd/full-report/switzerland_d6b0d504.html)
+- [Erudera - International Students in Switzerland](https://erudera.com/news/record-78000-international-students-are-studying-in-switzerland-this-academic-year/)
+- [Fragomen - Swiss Immigration Quotas 2025](https://www.fragomen.com/insights/swiss-residence-permit-quotas-2025.html)
+
+### Translation Services and Pricing
+- [SwissGlobal - Translation Costs](https://swissglobal.ch/en/blog/how-much-does-a-translation-cost/)
+- [UniTranslate - Certified Translation Costs](https://www.unitranslate.ch/en/kosten-beglaubigte-uebersetzung)
+- [Swiss Relocation Services - Pricing](https://swiss-relocation.ch/en/prices/)
+
+### Competitive Analysis
+- [DeepL Pro](https://www.deepl.com/en/pro)
+- [Taia - DeepL vs Google Translate Comparison](https://taia.io/blog/technology-and-translation/deepl-vs-google-translate-vs-taia-best-ai-file-translators-compared/)
+
+### Expat Challenges
+- [FocusSwiss - First Month Difficulties](https://www.focusswiss.com/en/switzerland-first-month-7-difficulties/)
+- [Valentina Chigliaro - Being an Expat in Switzerland](https://www.valentinachigliaro.com/articles/being-an-expat-in-switzerland)
+- [PMC - Language Barriers in Healthcare](https://pmc.ncbi.nlm.nih.gov/articles/PMC6598246/)
+
+### Data Protection
+- [Swiss Federal Government - nFADP](https://www.kmu.admin.ch/kmu/en/home/facts-and-trends/digitization/data-protection/new-federal-act-on-data-protection-nfadp.html)
+- [CookieYes - Switzerland FADP](https://www.cookieyes.com/blog/switzerland-fadp/)
+
+### Insurance and Liability
+- [Suited Insurance - Translator Insurance](https://www.suited.insure/business-insurance/translator-insurance)
+- [Hiscox - Interpreters and Translators Insurance](https://www.hiscox.com/small-business-insurance/professional-business-insurance/interpreters-and-translators-insurance)
+
+### Community Resources
+- [English Forum Switzerland](https://www.englishforum.ch/)
+- [Swiss Ready - Document Services](https://www.swiss-ready.com/our-services/translation-documents)
+
+---
+
+*Document created: January 2026*
+*Last updated: January 2026*
+*Author: BriefBot Development Team*

--- a/docs/SWISS_TERMINOLOGY_GLOSSARY.md
+++ b/docs/SWISS_TERMINOLOGY_GLOSSARY.md
@@ -1,0 +1,498 @@
+# Swiss Bureaucratic Terminology Glossary
+
+> **Purpose**: Reference document for accurate OCR interpretation and translation of Swiss official correspondence.
+> **Languages**: German (DE), French (FR), Italian (IT), English (EN)
+> **Last Updated**: 2026-01-22
+
+---
+
+## Table of Contents
+
+1. [Tax Terminology](#1-tax-terminology)
+2. [Health Insurance Terminology](#2-health-insurance-terminology)
+3. [Immigration & Residence Permits](#3-immigration--residence-permits)
+4. [Social Security (Three-Pillar System)](#4-social-security-three-pillar-system)
+5. [Housing & Registration](#5-housing--registration)
+6. [Debt Collection & Enforcement](#6-debt-collection--enforcement)
+7. [Legal & Administrative Terms](#7-legal--administrative-terms)
+8. [Common Abbreviations](#8-common-abbreviations)
+9. [Formal Letter Phrases](#9-formal-letter-phrases)
+10. [Language-Specific Considerations](#10-language-specific-considerations)
+11. [False Friends & Translation Pitfalls](#11-false-friends--translation-pitfalls)
+12. [Compound Word Patterns](#12-compound-word-patterns)
+
+---
+
+## 1. Tax Terminology
+
+### Core Tax Terms
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| Steuererklarung | Declaration d'impot | Dichiarazione fiscale | Tax return/declaration |
+| Steuerveranlagung | Taxation | Tassazione | Tax assessment |
+| Veranlagungsverfugung | Decision de taxation | Decisione di tassazione | Assessment notice |
+| Veranlagungsprotokoll | Protocole de taxation | Protocollo di tassazione | Assessment protocol |
+| Schlussrechnung | Decompte final | Conteggio finale | Final invoice/settlement |
+| Steueramt | Administration fiscale | Ufficio delle imposte | Tax office |
+| Quellensteuer | Impot a la source | Imposta alla fonte | Withholding tax |
+| Verrechnungssteuer | Impot anticipé | Imposta preventiva | Withholding tax (on securities) |
+| Steuerbescheid | Avis d'imposition | Avviso di tassazione | Tax assessment notice |
+| Freibetrag | Deduction | Deduzione | Tax-free allowance |
+| Einsprache | Reclamation | Reclamo | Objection/appeal |
+
+### Quellensteuer (Withholding Tax) - Special Category
+
+Quellensteuer applies to:
+- **B permit holders** (Aufenthaltsbewilligung) - residence permit
+- **L permit holders** (Kurzaufenthaltsbewilligung) - short-term permit
+- **Cross-border commuters** (Grenzganger)
+
+**Key thresholds:**
+- Income over CHF 120,000/year requires full tax return
+- Deadline for correction requests: **31 March** of following year
+
+**Exemptions:**
+- C permit holders (permanent residence)
+- Spouses of Swiss citizens or C permit holders
+
+### Tax Deadlines
+
+| Context | German | French | English |
+|---------|--------|--------|---------|
+| Within 30 days | innert 30 Tagen | dans un delai de 30 jours | within 30 days |
+| By the latest | bis spatestens | au plus tard | by the latest |
+| Extension request | Fristverlangerung | Prolongation de delai | Extension request |
+
+---
+
+## 2. Health Insurance Terminology
+
+### Core Health Insurance Terms
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| Grundversicherung | Assurance de base | Assicurazione di base | Basic/compulsory insurance |
+| Krankenkasse | Caisse maladie | Cassa malati | Health insurer |
+| Franchise | Franchise | Franchigia | Deductible |
+| Selbstbehalt | Quote-part | Partecipazione ai costi | Co-payment (10% after deductible) |
+| Pramie | Prime | Premio | Premium |
+| Unfallversicherung | Assurance accidents | Assicurazione infortuni | Accident insurance |
+| Zusatzversicherung | Assurance complementaire | Assicurazione complementare | Supplementary insurance |
+
+### Key Laws and Acronyms
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| KVG (Krankenversicherungsgesetz) | LAMal (Loi federale sur l'assurance-maladie) | LAMal (Legge federale sull'assicurazione malattie) | Federal Health Insurance Act |
+
+### Franchise Levels (2025-2026)
+
+- Adults: CHF 300 to CHF 2,500 (annual)
+- Children: CHF 0 to CHF 600 (annual)
+- Selbstbehalt maximum: CHF 700/year (adults), CHF 350/year (children)
+
+---
+
+## 3. Immigration & Residence Permits
+
+### Permit Types
+
+| Permit | German | French | Italian | Description |
+|--------|--------|--------|---------|-------------|
+| **L** | Kurzaufenthaltsbewilligung | Autorisation de sejour de courte duree | Permesso di dimora temporanea | Short-term (up to 1 year, max 24 months) |
+| **B** | Aufenthaltsbewilligung | Autorisation de sejour | Permesso di dimora | Residence permit (5 years EU/EFTA, 1 year initial for others) |
+| **C** | Niederlassungsbewilligung | Autorisation d'etablissement | Permesso di domicilio | Settlement/permanent residence (after 5-10 years) |
+| **G** | Grenzgangerbewilligung | Autorisation frontaliere | Permesso per frontalieri | Cross-border commuter |
+| **N** | Ausweis N | Livret N | Permesso N | Asylum seeker |
+| **F** | Ausweis F | Livret F | Permesso F | Provisionally admitted |
+| **S** | Ausweis S | Livret S | Permesso S | People in need of protection |
+
+### Key Immigration Authorities
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| Staatssekretariat fur Migration (SEM) | Secretariat d'Etat aux migrations | Segreteria di Stato della migrazione | State Secretariat for Migration |
+| Migrationsamt | Office de la population | Ufficio della migrazione | Migration office |
+| Fremdenpolizei | Police des etrangers | Polizia degli stranieri | Foreigners' police |
+
+### C Permit Requirements
+
+- **Standard**: 10 years continuous residence
+- **Accelerated**: 5 years for EU-15/EFTA, US, Canada, and those with "extraordinary integration"
+- **Integration criteria**: Language proficiency, economic self-sufficiency, civic knowledge
+
+---
+
+## 4. Social Security (Three-Pillar System)
+
+### Pillar 1: State Pension (AHV/AVS)
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| AHV (Alters- und Hinterlassenenversicherung) | AVS (Assurance vieillesse et survivants) | AVS (Assicurazione vecchiaia e superstiti) | Old-age and survivors' insurance |
+| IV (Invalidenversicherung) | AI (Assurance-invalidite) | AI (Assicurazione invalidita) | Disability insurance |
+| EO (Erwerbsersatzordnung) | APG (Allocations pour perte de gain) | IPG (Indennita per perdita di guadagno) | Income compensation |
+| EL (Erganzungsleistungen) | PC (Prestations complementaires) | PC (Prestazioni complementari) | Supplementary benefits |
+
+**Contribution rate (2025):** 10.60% of gross salary (split 50/50 employer-employee)
+
+### Pillar 2: Occupational Pension (BVG/LPP)
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| BVG (Berufliche Vorsorge) | LPP (Loi sur la prevoyance professionnelle) | LPP (Legge sulla previdenza professionale) | Occupational pension law |
+| Pensionskasse | Caisse de pension | Cassa pensione | Pension fund |
+| Freizugigkeitskonto | Compte de libre passage | Conto di libero passaggio | Vested benefits account |
+| Koordinationsabzug | Deduction de coordination | Deduzione di coordinamento | Coordination deduction |
+
+**Goal:** Together with AHV, should cover ~60% of last income
+
+### Pillar 3: Private Pension
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| Saule 3a | Pilier 3a | Pilastro 3a | Restricted private pension (tax-advantaged) |
+| Saule 3b | Pilier 3b | Pilastro 3b | Unrestricted private savings |
+
+### Other Social Insurance
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| ALV (Arbeitslosenversicherung) | AC (Assurance-chomage) | AD (Assicurazione disoccupazione) | Unemployment insurance |
+| UV (Unfallversicherung) | AA (Assurance-accidents) | AINF (Assicurazione infortuni) | Accident insurance |
+| SUVA (Schweizerische Unfallversicherungsanstalt) | CNA (Caisse nationale suisse d'assurance) | INSAI (Istituto nazionale svizzero di assicurazione) | Swiss National Accident Insurance Fund |
+| RAV (Regionales Arbeitsvermittlungszentrum) | ORP (Office regional de placement) | URC (Ufficio regionale di collocamento) | Regional Employment Center |
+
+---
+
+## 5. Housing & Registration
+
+### Registration Terms
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| Wohnsitz | Domicile | Domicilio | Residence/domicile |
+| Anmeldung | Annonce d'arrivee | Notifica di arrivo | Registration |
+| Abmeldung | Annonce de depart | Notifica di partenza | Deregistration |
+| Umzugsmeldung | Declaration de demenagement | Notifica di trasloco | Change of address notification |
+| Einwohnerkontrolle | Controle des habitants | Controllo abitanti | Residents' registration office |
+| Gemeindehaus | Maison communale | Casa comunale | Municipal office |
+| Heimatschein | Acte d'origine | Attestato di attinenza | Certificate of origin |
+| Wochenaufenthalter | Sejour hebdomadaire | Dimorante settimanale | Weekly resident (commuter) |
+
+### Registration Requirements
+
+- **Deadline**: 8-14 days after moving (varies by canton)
+- **Required for**: Bank accounts, employment, rental contracts, property purchase
+- **Penalty**: Fines for non-compliance
+
+---
+
+## 6. Debt Collection & Enforcement
+
+### Core Debt Collection Terms
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| Betreibung | Poursuite | Esecuzione | Debt enforcement/collection |
+| Betreibungsamt | Office des poursuites | Ufficio esecuzioni | Debt collection office |
+| Betreibungsbegehren | Requisition de poursuite | Domanda di esecuzione | Debt collection request |
+| Zahlungsbefehl | Commandement de payer | Precetto esecutivo | Payment order/summons |
+| Rechtsvorschlag | Opposition | Opposizione | Objection to payment order |
+| Fortsetzungsbegehren | Requisition de continuer | Domanda di continuazione | Request for continuation |
+| Pfandung | Saisie | Pignoramento | Seizure of assets |
+| Konkurs | Faillite | Fallimento | Bankruptcy |
+| Konkursamt | Office des faillites | Ufficio dei fallimenti | Bankruptcy office |
+| Betreibungsregisterauszug | Extrait du registre des poursuites | Estratto dell'ufficio esecuzioni | Debt collection register extract |
+
+### Types of Debt Enforcement
+
+| German | French | English |
+|--------|--------|---------|
+| Betreibung auf Pfandung | Poursuite par voie de saisie | Enforcement by seizure (individuals) |
+| Betreibung auf Konkurs | Poursuite par voie de faillite | Enforcement by bankruptcy (companies) |
+| Betreibung auf Pfandverwertung | Poursuite en realisation du gage | Enforcement by pledged property |
+
+### Key Deadlines
+
+- **Rechtsvorschlag (objection)**: 10 days from receiving Zahlungsbefehl
+- **Payment deadline**: 20 days if no objection filed
+
+---
+
+## 7. Legal & Administrative Terms
+
+### Administrative Decisions & Appeals
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| Verfugung | Decision | Decisione | Administrative decision/decree |
+| Einsprache | Reclamation/Opposition | Reclamo/Opposizione | Objection |
+| Beschwerde | Recours | Ricorso | Appeal |
+| Rechtsmittel | Voie de droit | Rimedio giuridico | Legal remedy |
+| Frist | Delai | Termine | Deadline |
+| Rechtsmittelbelehrung | Indication des voies de droit | Indicazione dei rimedi giuridici | Information on legal remedies |
+
+### Standard Appeal Deadlines
+
+- **General administrative decisions**: 30 days
+- **Summary proceedings**: 10 days
+- **Supreme Court appeals**: 30 days (if amount > CHF 30,000)
+
+### Action Required Language
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| Sie werden aufgefordert | Vous etes prie(e) de | La preghiamo di | You are requested to |
+| Bitte beachten Sie | Veuillez noter | La preghiamo di notare | Please note |
+| Wir machen Sie darauf aufmerksam | Nous attirons votre attention | Desideriamo richiamare la Sua attenzione | We draw your attention to |
+| Es wird darauf hingewiesen | Il est precise que | Si precisa che | It is noted that |
+
+---
+
+## 8. Common Abbreviations
+
+### Social Security & Insurance
+
+| Abbreviation | German | French | Italian | English |
+|--------------|--------|--------|---------|---------|
+| AHV | Alters- und Hinterlassenenversicherung | AVS | AVS | Old-age and survivors' insurance |
+| IV | Invalidenversicherung | AI | AI | Disability insurance |
+| BVG | Berufliche Vorsorge | LPP | LPP | Occupational pension |
+| ALV | Arbeitslosenversicherung | AC | AD | Unemployment insurance |
+| EO | Erwerbsersatzordnung | APG | IPG | Income compensation |
+| EL | Erganzungsleistungen | PC | PC | Supplementary benefits |
+| SUVA | Schweizerische Unfallversicherungsanstalt | CNA | INSAI | Accident insurance fund |
+| KVG | Krankenversicherungsgesetz | LAMal | LAMal | Health insurance law |
+
+### Administrative Bodies
+
+| Abbreviation | German | French | Italian | English |
+|--------------|--------|--------|---------|---------|
+| SEM | Staatssekretariat fur Migration | SEM | SEM | State Secretariat for Migration |
+| RAV | Regionales Arbeitsvermittlungszentrum | ORP | URC | Regional Employment Center |
+| SVA | Sozialversicherungsanstalt | Caisse AVS | Cassa AVS | Social insurance institution |
+
+### Canton Codes
+
+| Code | German | French | Italian |
+|------|--------|--------|---------|
+| ZH | Zurich | Zurich | Zurigo |
+| BE | Bern | Berne | Berna |
+| GE | Genf | Geneve | Ginevra |
+| VD | Waadt | Vaud | Vaud |
+| TI | Tessin | Tessin | Ticino |
+| BS | Basel-Stadt | Bale-Ville | Basilea Citta |
+
+---
+
+## 9. Formal Letter Phrases
+
+### Openings
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| Sehr geehrte Damen und Herren | Madame, Monsieur | Gentili Signore e Signori | Dear Sir/Madam |
+| Sehr geehrte Frau [Name] | Madame | Gentile Signora | Dear Ms. [Name] |
+| Sehr geehrter Herr [Name] | Monsieur | Gentile Signor | Dear Mr. [Name] |
+
+### Reference Phrases
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| Bezugnehmend auf | En reference a | Con riferimento a | With reference to |
+| Betreffend | Concernant | Concernente | Regarding |
+| Ihr Schreiben vom | Votre lettre du | La Sua lettera del | Your letter of |
+
+### Closings
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| Mit freundlichen Grussen | Avec nos salutations distinguees | Distinti saluti | Yours sincerely |
+| Freundliche Grusse | Meilleures salutations | Cordiali saluti | Kind regards |
+| Hochachtungsvoll (formal/dated) | Veuillez agreer... | Con osservanza | Respectfully |
+
+### Swiss-Specific Conventions
+
+- **No comma** after salutation in Swiss German correspondence
+- **No punctuation** after closing
+- Correspondence begins with **capital letter** after salutation (Swiss standard)
+
+---
+
+## 10. Language-Specific Considerations
+
+### Swiss German (Schweizerdeutsch) Particularities
+
+**Distinctly Swiss prepositions and terms:**
+
+| Swiss German | Standard German | English |
+|--------------|-----------------|---------|
+| innert | innerhalb | within |
+| ob (causal) | wegen | because of |
+| allfállig | eventuell | possible/any |
+| anlasslich | bei Gelegenheit von | on the occasion of |
+
+**Administrative style:**
+- Uses Standard German (Hochdeutsch) in written form
+- Swiss German dialects used only in speech
+- "Amtsdeutsch" (bureaucratic German) prevalent in official documents
+
+### Swiss French Particularities
+
+**Helvetisms (French):**
+
+| Swiss French | Standard French | English |
+|--------------|-----------------|---------|
+| septante | soixante-dix | 70 |
+| huitante/octante | quatre-vingts | 80 |
+| nonante | quatre-vingt-dix | 90 |
+| natel | telephone portable | mobile phone |
+| action (sale) | promotion | sale/promotion |
+
+### Swiss Italian (Italiano Svizzero) Particularities
+
+**Helvetisms (Italian):**
+
+| Swiss Italian | Standard Italian | English |
+|---------------|------------------|---------|
+| licenza di condurre | patente di guida | driving license |
+| riservazione | prenotazione | reservation |
+| azione (sale) | promozione | sale/promotion |
+
+**Grammatical notes:**
+- **Passato remoto** almost never used (stick to Passato Prossimo)
+- Administrative texts are notably clearer than Italian counterparts
+- Many terms are calques from German/French
+
+---
+
+## 11. False Friends & Translation Pitfalls
+
+### German-English False Friends
+
+| German | Looks like | Actually means |
+|--------|------------|----------------|
+| Gift | gift | poison |
+| Chef | chef | boss/manager |
+| Rat | rat | advice/council |
+| Gymnasium | gymnasium | secondary school |
+| Fabrik | fabric | factory |
+| Rente | rent | pension |
+| Mist | mist | manure |
+| Brand | brand | fire |
+| aktuell | actually | current/up-to-date |
+| Termin | term | appointment |
+| Kost | cost | food/board |
+
+### Terms with No Direct English Equivalent
+
+| German | Approximate English | Context |
+|--------|---------------------|---------|
+| Quellensteuer | withholding tax at source | Tax deducted directly from salary |
+| Pensionskasse | pension fund | Pillar 2 occupational pension |
+| Wochenaufenthalter | weekly resident | Commuter staying in another canton during week |
+| Heimatschein | certificate of origin | Proof of citizenship in home municipality |
+| Betreibung | debt enforcement proceedings | Formal collection process |
+
+### Context-Dependent Meanings
+
+| Term | Context 1 | Context 2 |
+|------|-----------|-----------|
+| Verfugung | Administrative decision (admin law) | Court order (civil law) |
+| Einsprache | Tax objection | Opposition to debt collection |
+| Franchise | Health insurance deductible | Business franchise |
+| Koordinationsabzug | Pension coordination deduction | Different calculation methods |
+
+---
+
+## 12. Compound Word Patterns
+
+### German Compound Word Structure
+
+German bureaucratic language extensively uses compound words. Understanding the pattern helps with OCR and translation:
+
+**Pattern**: [Modifier] + [Modifier] + [Base word]
+
+**Examples:**
+
+| Compound | Components | English |
+|----------|------------|---------|
+| Steuererklarung | Steuer (tax) + Erklarung (declaration) | Tax declaration |
+| Krankenversicherung | Kranken (sick) + Versicherung (insurance) | Health insurance |
+| Aufenthaltsbewilligung | Aufenthalt (stay) + Bewilligung (permit) | Residence permit |
+| Sozialversicherungsanstalt | Sozial (social) + Versicherung (insurance) + Anstalt (institution) | Social insurance institution |
+| Arbeitslosenversicherung | Arbeits (work) + losen (less) + Versicherung (insurance) | Unemployment insurance |
+| Einkommensteuererklarung | Einkommen (income) + Steuer (tax) + Erklarung (declaration) | Income tax declaration |
+
+### Common Compound Suffixes in Official Documents
+
+| Suffix | Meaning | Example |
+|--------|---------|---------|
+| -amt | office | Steueramt (tax office) |
+| -behorde | authority | Steuerbehorde (tax authority) |
+| -bewilligung | permit | Aufenthaltsbewilligung |
+| -erklarung | declaration | Steuererklarung |
+| -versicherung | insurance | Krankenversicherung |
+| -verfugung | decree/order | Veranlagungsverfugung |
+| -begehren | request | Betreibungsbegehren |
+| -vorschlag | proposal/objection | Rechtsvorschlag |
+
+---
+
+## Quick Reference: Document Types
+
+### Common Official Documents
+
+| Document Type | German | French | Italian |
+|--------------|--------|--------|---------|
+| Tax return | Steuererklarung | Declaration d'impot | Dichiarazione fiscale |
+| Tax assessment | Steuerveranlagung | Taxation | Tassazione |
+| Health insurance card | Versicherungskarte | Carte d'assure | Tessera assicurativa |
+| Residence permit | Aufenthaltsbewilligung | Autorisation de sejour | Permesso di dimora |
+| Payment order | Zahlungsbefehl | Commandement de payer | Precetto esecutivo |
+| Registration confirmation | Anmeldebestatigung | Attestation de domicile | Conferma di notifica |
+| Pension statement | Vorsorgeausweis | Certificat de prevoyance | Certificato di previdenza |
+
+---
+
+## References
+
+### Official Resources
+
+- **TERMDAT**: Federal Administration terminology database (400,000+ entries in DE/FR/IT/RM/EN)
+  - URL: https://www.termdat.bk.admin.ch
+- **ch.ch**: Official Swiss government portal
+- **ahv-iv.ch**: Social security information
+
+### Relevant Legislation
+
+- **KVG/LAMal**: Federal Health Insurance Act
+- **BVG/LPP**: Occupational Pension Act
+- **SchKG/LP**: Debt Collection and Bankruptcy Act
+- **AIG/LEI**: Foreign Nationals and Integration Act
+
+---
+
+## Notes for OCR Implementation
+
+### OCR Challenges
+
+1. **German compound words**: May be hyphenated at line breaks
+2. **Umlauts**: a, o, u must be correctly recognized (not ae, oe, ue in Swiss context)
+3. **French accents**: e, e, a, u, i, c critical for meaning
+4. **Italian accents**: a, e, i, o, u
+5. **Abbreviations**: Context-dependent (IV can be disability insurance or Roman numeral)
+
+### Translation Priorities
+
+1. **Deadlines**: Always highlight and translate precisely
+2. **Action required**: Flag any "Sie werden aufgefordert" / "Vous etes prie" patterns
+3. **Amounts**: Preserve CHF currency format
+4. **References**: Keep original reference numbers intact
+5. **Legal remedies**: Translate Rechtsmittelbelehrung sections completely
+
+---
+
+*This glossary is maintained as part of the BriefBot project for Swiss official mail translation.*

--- a/docs/research/USER_PERSONAS.md
+++ b/docs/research/USER_PERSONAS.md
@@ -1,0 +1,675 @@
+# BriefBot User Research: Personas and Journey Maps
+
+> **Document Type**: UX Research
+> **Created**: 2026-01-22
+> **Last Updated**: 2026-01-22
+> **Purpose**: Guide product decisions with evidence-based user understanding
+
+---
+
+## Executive Summary
+
+BriefBot targets Swiss residents who struggle with official correspondence due to language barriers, bureaucratic complexity, or unfamiliarity with the Swiss administrative system. This document synthesizes research on five primary user segments, their pain points, emotional journeys, and current workarounds.
+
+**Key Insight**: The Swiss tri-level government system (federal, cantonal, municipal) combined with four official languages creates unique challenges not found in other countries. Users face not just translation needs but interpretation of bureaucratic context.
+
+---
+
+## Market Context
+
+### The Swiss Bureaucratic Landscape
+
+Switzerland's administrative system presents unique challenges:
+
+- **26 cantons** with their own constitutions, tax laws, and procedures
+- **2,131 municipalities** with varying local requirements
+- **4 official languages**: German (63%), French (23%), Italian (8%), Romansh (<1%)
+- **Diglossia in German-speaking regions**: Swiss German (spoken) vs. Standard German (written)
+- **Withholding tax (Quellensteuer)** for non-C permit holders
+- **Cantonal variations** in integration requirements, tax rates, and permit processes
+
+### Current Market Solutions
+
+Existing solutions are fragmented and often inadequate:
+
+1. **Professional translation services** (Apostroph, Translayte, ABC Translation)
+   - Expensive (CHF 30-50+ per document)
+   - Slow turnaround (24-48 hours minimum)
+   - Overkill for understanding mail (designed for legal certification)
+
+2. **Generic translation apps** (Google Translate, DeepL)
+   - Cannot interpret Swiss bureaucratic context
+   - Miss canton-specific terminology
+   - No guidance on required actions or deadlines
+
+3. **Community forums** (English Forum Switzerland, Reddit r/Switzerland, Expat.com)
+   - Slow response times
+   - Inconsistent quality of advice
+   - Privacy concerns about sharing official documents
+
+4. **Paid consultants** (Expat Services, Check4You, relocation agencies)
+   - Very expensive (CHF 100-300+ per consultation)
+   - Not accessible for routine correspondence
+   - Overkill for simple letters
+
+**Gap**: No tool combines instant OCR, contextual translation, AND Swiss bureaucratic interpretation in a privacy-respecting, affordable package.
+
+---
+
+## User Segments Overview
+
+| Segment | Population | Primary Pain | Urgency | Willingness to Pay |
+|---------|------------|--------------|---------|-------------------|
+| New Expats | ~80,000/year | Everything is unfamiliar | High | High |
+| Long-term Non-Native Speakers | ~2M residents | Bureaucratic German | Medium | Medium |
+| Immigrants/Refugees | ~150,000 | Language + system barriers | Very High | Low |
+| Elderly Swiss | ~1.5M 65+ | Complex modern language | Low | Medium |
+| Young Adults | ~500,000 18-25 | First-time bureaucracy | Medium | Low-Medium |
+
+---
+
+## Detailed User Personas
+
+---
+
+### Persona 1: Maria - The Overwhelmed New Expat
+
+**Demographics**
+- Age: 34
+- Origin: Brazil
+- Location: Zurich (German-speaking)
+- Occupation: Software engineer at a multinational
+- Time in Switzerland: 3 months
+- Permit: B (5-year EU/EFTA equivalent via company sponsorship)
+- Languages: Portuguese (native), English (fluent), German (A1)
+
+**Background**
+Maria moved to Zurich for a senior role at a tech company. Her employer handled the initial permit paperwork, but now she must navigate daily bureaucracy alone. She studied German in college but finds Swiss official letters incomprehensible.
+
+**Goals**
+- Settle into Swiss life without costly mistakes
+- Understand what actions official letters require
+- Meet deadlines she may not even know exist
+- Eventually integrate into Swiss society
+
+**Frustrations**
+- "Every letter looks urgent but I can't tell which ones actually are"
+- "The German I learned is nothing like what's in these letters"
+- "My colleagues say 'just ask at the Gemeinde' but I don't know what to ask"
+- "I'm scared I'll miss something important and get fined or deported"
+
+**Behaviors**
+- Photographs every official letter immediately
+- Creates Google Keep notes for each document
+- Asks German-speaking colleagues for translation help
+- Has used Google Translate but results are confusing
+- Pays CHF 50/month for an expat advisory service but it's slow
+
+**Quote**
+> "I'm a senior engineer who manages complex systems, but Swiss bureaucracy makes me feel incompetent."
+
+**Scenarios**
+1. Receives first Steuererklaerung (tax declaration) - has 30 days to respond
+2. Gets health insurance comparison letter - must choose by end of month
+3. Receives mysterious letter from Einwohnerkontrolle - doesn't know it's routine
+4. Bill from Serafe (TV license) - thinks it might be a scam
+
+**Tech Comfort**: Very high - prefers mobile apps, uses cloud storage
+
+**Emotional State When Receiving Mail**
+```
+Letter arrives → Anxiety ("What now?") → Attempts translation →
+Confusion → Seeks help → Delayed action → Relief or Panic
+```
+
+---
+
+### Persona 2: Ahmed - The Struggling Refugee
+
+**Demographics**
+- Age: 28
+- Origin: Syria
+- Location: Geneva (French-speaking)
+- Occupation: In integration program, seeking work
+- Time in Switzerland: 2 years
+- Permit: F (temporarily admitted)
+- Languages: Arabic (native), French (B1), German (none)
+
+**Background**
+Ahmed arrived as a refugee and has been in Switzerland for two years. He's completed basic French courses and is actively seeking employment. His F permit limits his mobility and job options. He relies on support from the Swiss Refugee Council but wants independence.
+
+**Goals**
+- Understand his rights and obligations under F permit
+- Respond correctly to all official communications
+- Not miss any integration requirements
+- Eventually obtain B permit and work freely
+
+**Frustrations**
+- "I can speak French in shops but official letters use different French"
+- "My case worker is helpful but I can only see her once a month"
+- "I'm afraid one wrong response will affect my permit"
+- "Integration requirements differ by canton and I don't understand which apply to me"
+
+**Behaviors**
+- Keeps every letter in a folder, even if he doesn't understand it
+- Asks friends from his community to translate
+- Sometimes waits too long to respond out of fear of making mistakes
+- Has missed deadlines because he didn't understand urgency
+- Uses WhatsApp groups in Arabic to ask about Swiss bureaucracy
+
+**Quote**
+> "I don't know what I don't know. Each letter might be routine or life-changing."
+
+**Scenarios**
+1. Letter about integration agreement review - must prepare documents
+2. Notice about French language test requirement - deadline unclear
+3. Information about changing cantons - needs to understand restrictions
+4. Letter from social services about reporting requirements
+
+**Tech Comfort**: Medium - uses smartphone extensively but limited data plan
+
+**Emotional State When Receiving Mail**
+```
+Letter arrives → Fear ("Is this about my permit?") →
+Isolation (no one to ask) → Delay → Escalating anxiety →
+Last-minute scramble → Relief or crisis
+```
+
+---
+
+### Persona 3: Thomas - The Long-Term Resident
+
+**Demographics**
+- Age: 52
+- Origin: UK
+- Location: Bern (German-speaking)
+- Occupation: Financial analyst at international bank
+- Time in Switzerland: 15 years
+- Permit: C (settlement)
+- Languages: English (native), German (B2 conversational, C1 reading)
+
+**Background**
+Thomas has lived in Switzerland for 15 years and speaks good German. However, he still struggles with "Amtsdeutsch" (bureaucratic German) - the formal language of official correspondence. His everyday German is excellent but official letters require a dictionary and 30+ minutes to decode.
+
+**Goals**
+- Quickly understand the gist of letters without deep reading
+- Not waste time on unimportant correspondence
+- Stay compliant with changing regulations
+- Help his elderly Swiss mother-in-law with her letters
+
+**Frustrations**
+- "I speak German every day but these letters might as well be Latin"
+- "Even my Swiss wife finds them confusing sometimes"
+- "I shouldn't need 30 minutes to understand a simple notice"
+- "The language is deliberately obscure - it's not just me"
+
+**Behaviors**
+- Has a "to translate" pile that grows
+- Sometimes ignores letters that seem unimportant (risky)
+- Uses dict.cc for individual words but misses context
+- Occasionally asks his wife but feels dependent
+
+**Quote**
+> "Fifteen years here and I still can't decode an official letter quickly. That's a failure of the system, not me."
+
+**Scenarios**
+1. Annual tax correction notice - needs to verify calculations
+2. New voting materials with legal terminology
+3. Pension fund statement with projections to understand
+4. Building regulations notice about renovations
+
+**Tech Comfort**: High - desktop preference, uses mobile when necessary
+
+**Emotional State When Receiving Mail**
+```
+Letter arrives → Mild annoyance → Quick scan attempt →
+Frustration at jargon → Add to pile → Eventual dedicated time →
+Understanding (usually) or asking wife
+```
+
+---
+
+### Persona 4: Rosa - The Elderly Swiss Resident
+
+**Demographics**
+- Age: 74
+- Origin: Switzerland (Italian-speaking Ticino, moved to Zurich)
+- Location: Zurich (German-speaking)
+- Occupation: Retired teacher
+- Time in current canton: 30 years
+- Permit: N/A (Swiss citizen)
+- Languages: Italian (native), German (B2), French (A2)
+
+**Background**
+Rosa grew up in Ticino and moved to Zurich after marriage. While she speaks German well, she finds modern official correspondence increasingly complex. Digitalization, new terminology, and longer documents make her feel left behind. Her children live abroad and can't help easily.
+
+**Goals**
+- Stay independent and manage her affairs
+- Understand health insurance and AHV (pension) correspondence
+- Not fall for scams disguised as official letters
+- Feel confident about important decisions
+
+**Frustrations**
+- "Letters are longer and more complicated than they used to be"
+- "I can't tell what's truly important anymore"
+- "My children try to help by phone but they're busy"
+- "I'm worried about missing something important for my health coverage"
+
+**Behaviors**
+- Reads letters multiple times but often remains confused
+- Highlights parts she doesn't understand
+- Calls the Gemeinde but waits on hold for long periods
+- Sometimes pays for services she doesn't need out of confusion
+- Asks neighbors but feels embarrassed about her difficulty
+
+**Quote**
+> "I've lived here 30 years and suddenly I can't understand my own country's letters."
+
+**Scenarios**
+1. Health insurance premium change notice - should she switch?
+2. AHV pension adjustment letter - is the amount correct?
+3. Property tax reassessment - should she appeal?
+4. Suspicious "official" letter - is it a scam?
+
+**Tech Comfort**: Low - has smartphone but prefers calls, uses WhatsApp with family
+
+**Emotional State When Receiving Mail**
+```
+Letter arrives → Apprehension → Careful reading attempt →
+Confusion → Self-doubt → Seek help (embarrassing) →
+Dependent on others for decisions
+```
+
+---
+
+### Persona 5: Luca - The First-Time Adult
+
+**Demographics**
+- Age: 22
+- Origin: Switzerland (Italian background, raised in Zurich)
+- Location: Lausanne (French-speaking, for university)
+- Occupation: University student, part-time work
+- Time in current canton: 6 months
+- Permit: N/A (Swiss citizen)
+- Languages: German (native), French (B1), Italian (heritage speaker)
+
+**Background**
+Luca grew up in Zurich but moved to Lausanne for university. He's dealing with official bureaucracy independently for the first time. The canton change added French language to his challenges. His parents handled everything before, and he feels unprepared.
+
+**Goals**
+- Figure out adulting basics (taxes, insurance, registration)
+- Not make expensive mistakes in his first independent year
+- Understand French official letters (different from classroom French)
+- Build financial independence
+
+**Frustrations**
+- "My parents always handled this - I don't know where to start"
+- "I moved cantons and now everything is in French instead of German"
+- "I know I should file taxes but I literally don't know how"
+- "I feel stupid asking basic questions that adults should know"
+
+**Behaviors**
+- Screenshots letters and sends to parents via WhatsApp
+- Googles specific terms but gets lost in forums
+- Has procrastinated on health insurance choice for 2 months
+- Asks university friends who seem equally confused
+- Uses TikTok/Reddit for "adulting in Switzerland" content
+
+**Quote**
+> "School taught me calculus but not how to read a tax form. Why isn't this stuff explained anywhere?"
+
+**Scenarios**
+1. First tax return ever - completely lost
+2. Health insurance franchise choice - doesn't understand tradeoffs
+3. Canton registration in Vaud - all in French
+4. Scholarship letter with deadlines - urgent but confusing
+
+**Tech Comfort**: Very high - mobile-first, prefers visual explanations, short-form content
+
+**Emotional State When Receiving Mail**
+```
+Letter arrives → Ignore (initially) → Guilt builds →
+Ask parents → Feel embarrassed → Last-minute action →
+Learning slowly through mistakes
+```
+
+---
+
+## Cross-Persona Pain Points Matrix
+
+| Pain Point | Maria | Ahmed | Thomas | Rosa | Luca |
+|------------|-------|-------|--------|------|------|
+| Language barrier | High | Very High | Medium | Medium | Medium |
+| Bureaucratic jargon | High | High | High | High | Very High |
+| Unknown deadlines | Very High | Very High | Medium | High | Very High |
+| Fear of mistakes | Very High | Very High | Low | High | High |
+| Cost of help | Medium | Very High | Low | Medium | High |
+| Canton-specific rules | Very High | Very High | Low | Medium | Very High |
+| Scam vs. real confusion | High | Medium | Low | Very High | High |
+| Action item unclear | High | Very High | Medium | High | Very High |
+
+---
+
+## User Journey Maps
+
+### Journey 1: Tax Return (First-Time Filer)
+
+**Persona**: Maria (or Luca)
+
+```
+TIMELINE: 4 months
+
+PHASES:
+┌─────────────────┬─────────────────┬─────────────────┬─────────────────┐
+│  Letter Arrives │  Initial Panic  │ Help-Seeking    │  Filing         │
+│  (January)      │  (Week 1-2)     │ (Weeks 3-8)     │  (March-April)  │
+└─────────────────┴─────────────────┴─────────────────┴─────────────────┘
+
+ACTIONS:
+• Receives thick      • Attempts Google    • Posts on forums   • Pays for tax
+  envelope             Translate           • Asks colleagues     service (CHF 400)
+• Sees deadline       • Gets confused      • Considers paid    • Submits with
+• Opens, overwhelmed    results              service             uncertainty
+                      • Puts aside         • Gathers documents • Waits for result
+
+TOUCHPOINTS:
+• Mail               • Translation app    • Online forums     • Tax software/
+• Tax office          • Dictionary         • Colleagues         service
+  letter                                   • Tax advisors      • Cantonal portal
+
+EMOTIONS:
+😰 Anxious          😫 Overwhelmed      😓 Frustrated       😌 Relieved but
+                                                              unsatisfied
+
+PAIN POINTS:
+• "What is this?"   • "Translation      • "Everyone gives   • "Did I do it
+• "When is it        makes no sense"     different advice"   right?"
+  due?"             • "Where do I       • "This is so       • "Why was this
+                      start?"             expensive"          so hard?"
+
+OPPORTUNITIES FOR BRIEFBOT:
+✓ Instant letter     ✓ Step-by-step     ✓ "You need these   ✓ Pre-submission
+  identification       guidance           documents"          checklist
+✓ Deadline           ✓ Jargon           ✓ "Common mistakes  ✓ "What to expect
+  extraction           explanation        to avoid"           next"
+```
+
+### Journey 2: Health Insurance Selection
+
+**Persona**: Ahmed (or Maria)
+
+```
+TIMELINE: 3 months (arrival + deadline)
+
+PHASES:
+┌─────────────────┬─────────────────┬─────────────────┬─────────────────┐
+│  Arrival/Notice │  Research Phase │  Decision       │  Aftermath      │
+│  (Month 1)      │  (Month 2)      │  (Month 3)      │  (Ongoing)      │
+└─────────────────┴─────────────────┴─────────────────┴─────────────────┘
+
+ACTIONS:
+• Receives 3-month   • Compares ~50     • Picks one       • Receives bills
+  deadline notice      insurers           (overwhelmed)   • Discovers gaps
+• Gets comparison    • Doesn't          • Signs up        • May need to
+  letters             understand                           switch
+                       franchise
+
+TOUCHPOINTS:
+• Welcome letter     • Comparison       • Insurer website • Monthly
+• Comparison           websites         • Agent call        invoices
+  mailers            • Forums           • Signature       • Doctor visits
+                     • Advisors
+
+EMOTIONS:
+😟 Confused         😩 Analysis        😣 Uncertain      😤 Frustrated if
+                       paralysis                            wrong choice
+
+PAIN POINTS:
+• "Why 50 options?" • "What's          • "Is this the    • "I'm paying for
+• "What must I       franchise?"        best choice?"     things I don't
+  have?"            • "Same coverage,  • "What if I'm      need"
+                      different price?"   sick?"
+
+OPPORTUNITIES FOR BRIEFBOT:
+✓ Identify letter    ✓ Explain key     ✓ "Questions to   ✓ Interpret bills
+  type                 terms             ask"            ✓ Identify issues
+✓ Deadline           ✓ Canton-         ✓ "What this      ✓ When to switch
+  extraction           specific info     means for you"
+```
+
+### Journey 3: Permit Renewal
+
+**Persona**: Ahmed
+
+```
+TIMELINE: 2-3 months before expiry
+
+PHASES:
+┌─────────────────┬─────────────────┬─────────────────┬─────────────────┐
+│  Renewal Notice │  Document Prep  │  Submission     │  Waiting        │
+│  (2 months out) │  (6 weeks out)  │  (1 month out)  │  (Until decision)│
+└─────────────────┴─────────────────┴─────────────────┴─────────────────┘
+
+ACTIONS:
+• Receives notice    • Gathers passport • Submits forms   • Receives
+• Doesn't know       • Gets employment  • Pays fee          interim letter
+  all requirements    proof            • Waits           • Eventually gets
+• Seeks help         • May need                            decision
+                       language cert
+
+TOUCHPOINTS:
+• Migration office   • Employer        • Migration office • Mail
+  letter             • Language school • Online portal   • Portal status
+• Case worker        • Municipality
+
+EMOTIONS:
+😨 Fearful          😓 Stressed       😟 Anxious        😰 High anxiety
+                                                           until resolved
+
+PAIN POINTS:
+• "Is my permit     • "Which          • "Did I include  • "Why is it
+  in danger?"         documents         everything?"      taking so long?"
+• "What exactly       exactly?"       • "Will they call • "What if they
+  do they want?"    • "Where do I       if something's    say no?"
+                      get these?"        missing?"
+
+OPPORTUNITIES FOR BRIEFBOT:
+✓ Calm explanation   ✓ Document        ✓ Completeness   ✓ Interpret
+  of process           checklist         verification     status letters
+✓ Timeline           ✓ Where to get    ✓ "What happens  ✓ "What this
+  expectations         each item         next"            decision means"
+```
+
+---
+
+## Emotional Impact Analysis
+
+### Psychological Burden of Official Correspondence
+
+Research shows significant mental health impacts from bureaucratic uncertainty:
+
+**For immigrants specifically:**
+- 40% report clinical-level distress related to permit uncertainty
+- 140% increase in psychological distress among recent immigrants
+- Language barriers correlate with higher anxiety and depression rates
+
+**Key emotional patterns observed:**
+
+| Emotion | Trigger | Consequence |
+|---------|---------|-------------|
+| **Fear** | Unknown sender, permit-related | Avoidance, delayed response |
+| **Anxiety** | Any official envelope | Accumulated stress, health impact |
+| **Confusion** | Bureaucratic language | Decision paralysis |
+| **Shame** | Not understanding | Reluctance to seek help |
+| **Isolation** | No one to ask | Increased vulnerability |
+| **Frustration** | System complexity | Disengagement from civic life |
+
+### Protective Factors (What Helps)
+
+Research identifies these as reducing bureaucratic anxiety:
+
+1. **Social support** - Someone who can explain
+2. **Clear timelines** - Knowing what to do when
+3. **Comprehensible language** - Plain explanations
+4. **Confidence in compliance** - Knowing you've done it right
+5. **Quick resolution** - Faster understanding = less rumination
+
+**BriefBot can provide factors 2-5 instantly, supplementing factor 1.**
+
+---
+
+## Current Help-Seeking Behavior
+
+### Where Users Go Now
+
+| Resource | Pros | Cons |
+|----------|------|------|
+| **Friends/Family** | Free, trusted | Limited knowledge, privacy concerns |
+| **Online Forums** | Peer experience, free | Slow, unreliable, not personalized |
+| **Professional Translation** | Accurate, certified | Expensive, slow, no context |
+| **Expat Services** | Comprehensive | Very expensive (CHF 100-300/hour) |
+| **Google Translate** | Instant, free | No context, often wrong for bureaucracy |
+| **Municipal Office** | Official, free | Long waits, may not speak English, hours limited |
+| **Community Interpreters** | Cultural bridge | Availability varies by canton |
+
+### Key Finding
+
+**There is no fast, affordable, private solution that combines translation with Swiss bureaucratic context.**
+
+Users currently choose between:
+- **Fast but wrong** (Google Translate)
+- **Right but slow and expensive** (Professional services)
+- **Free but unreliable** (Forums, friends)
+
+---
+
+## Design Implications for BriefBot
+
+### Must-Have Features (Based on Research)
+
+1. **Instant OCR** - Users need answers now, not in 24 hours
+2. **Deadline extraction** - The #1 anxiety source across all personas
+3. **Action item identification** - "What do I need to do?"
+4. **Plain language summaries** - "What this letter means"
+5. **Canton-aware context** - Rules vary by location
+6. **Privacy-first** - Users share sensitive permit/tax info
+7. **Multilingual output** - Explain in user's preferred language
+
+### Nice-to-Have Features
+
+1. **Document type identification** - "This is a tax notice"
+2. **Urgency classification** - "This needs action within 14 days"
+3. **Required documents list** - "You'll need to gather X, Y, Z"
+4. **Common mistakes warnings** - "People often forget to..."
+5. **Follow-up tracking** - "You submitted this on [date]"
+
+### UX Considerations
+
+| Persona | Key UX Need |
+|---------|-------------|
+| Maria | Mobile-first, English output, professional tone |
+| Ahmed | Simple language, visual cues, low data usage |
+| Thomas | Quick summaries, desktop option, German output |
+| Rosa | Large text, simple interface, clear buttons |
+| Luca | Visual/card-based, short explanations, shareable |
+
+### Emotional Design
+
+- **Reduce anxiety**: Use calm language, avoid alarming colors
+- **Build confidence**: Confirm understanding, show completeness
+- **Respect privacy**: Emphasize data handling, allow deletion
+- **Enable autonomy**: Educate, don't just translate
+
+---
+
+## Success Metrics (User-Centered)
+
+### Primary Metrics
+
+| Metric | Definition | Target |
+|--------|------------|--------|
+| Time to understanding | Seconds from upload to comprehension | < 60 seconds |
+| Confidence score | User self-report: "I understand what to do" | > 4/5 |
+| Deadline awareness | % of users who identify deadline correctly | > 95% |
+| Return usage | Users who come back within 30 days | > 40% |
+
+### Secondary Metrics
+
+| Metric | Definition | Target |
+|--------|------------|--------|
+| Help escalation | Users who still need external help | < 20% |
+| Error reports | Translations reported as wrong | < 5% |
+| NPS | Net Promoter Score | > 40 |
+| Anxiety reduction | Self-reported pre/post anxiety | Significant drop |
+
+---
+
+## References and Sources
+
+### Expat Life and Challenges
+- [Expatway - Moving to Switzerland](https://expatway.ch/moving-to-switzerland/)
+- [IAmExpat Switzerland](https://www.iamexpat.ch/)
+- [Expat Services Switzerland](https://www.expatservices.ch/en/)
+
+### Immigration and Integration
+- ['Fortress' Switzerland? Challenges to Integrating Migrants, Refugees and Asylum-Seekers](https://link.springer.com/chapter/10.1007/978-3-030-67284-3_11)
+- [UNHCR Switzerland - Rights and Duties](https://help.unhcr.org/switzerland/rights-and-duties/)
+- [SEEP - Legal assistance for migrants](https://seep.ch/en/)
+
+### Swiss Administrative System
+- [The maze of authorities and bureaucratic structures](https://permis-etudiant.ch/the-maze-of-authorities-and-bureaucratic-structures/?lang=en)
+- [Swiss Cantons Guide](https://www.focusswiss.com/en/the-26-swiss-cantons-guide-to-administration-population-and-languages/)
+- [ch.ch - Official Swiss Government Portal](https://www.ch.ch/en/)
+
+### Language and Communication
+- [Swiss Standard German - Wikipedia](https://en.wikipedia.org/wiki/Swiss_Standard_German)
+- [Understanding Official Letters - BHDD.info](https://bhdd.info/en/understanding-official-letters/)
+- [CB Multilingual - Community Interpreting](https://cb-m.ch/en/interpreting-services-zurich/community-interpreting/)
+
+### Tax and Health Insurance
+- [Taxes in Switzerland for Expats - Alpian](https://www.alpian.com/blog/money/taxes-in-switzerland-for-expats)
+- [How to file income tax in Switzerland 2025 - Expatica](https://www.expatica.com/ch/finance/taxes/income-tax-switzerland-100013/)
+- [Health Insurance for Foreign Nationals - AXA](https://www.axa.ch/en/privatkunden/blog/health/tips-and-tricks/health-insurance-foreign-nationals.html)
+- [Health Insurance for Newcomers - Helsana](https://www.helsana.ch/en/individuals/knowledge-centre/health-insurance/newcomers.html)
+
+### Permits and Residence
+- [Swiss Residence Permits - ch.ch](https://www.ch.ch/en/documents-and-register-extracts/permits-for-living-in-switzerland/)
+- [B EU/EFTA permit - SEM](https://www.sem.admin.ch/sem/en/home/themen/aufenthalt/eu_efta/ausweis_b_eu_efta.html)
+
+### Mental Health and Immigration
+- [Immigration and Mental Health - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC5966037/)
+- [Anxiety Disorders among US Immigrants - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC5489350/)
+- [Immigration and Your Mental Health - James Immigration Law](https://jamesimmigrationlaw.com/immigration-and-your-mental-health-managing-stress-and-anxiety/)
+
+### Community Forums
+- [English Forum Switzerland](https://englishforum.forumotion.com/)
+- [Swiss Forum UK](https://swissforum.co.uk/)
+- [Expat.com Switzerland Forum](https://www.expat.com/en/forum/europe/switzerland/)
+
+---
+
+## Appendix: Interview Guide (For Future Research)
+
+### Screening Questions
+1. Do you currently live in Switzerland?
+2. Have you received official mail (from government, municipality, tax office, etc.) in the past 6 months?
+3. What is your native language?
+4. How would you rate your proficiency in [German/French/Italian]?
+
+### Core Questions
+1. Walk me through the last time you received an official letter. What did you do?
+2. What was the most confusing official letter you've received? Why?
+3. Have you ever missed a deadline because you didn't understand a letter?
+4. Where do you go for help when you don't understand official correspondence?
+5. How does receiving official mail make you feel?
+6. What would an ideal solution look like for you?
+
+### Usability Test Tasks (For BriefBot)
+1. Upload this [sample tax letter] and tell me what action you need to take
+2. What is the deadline mentioned in this letter?
+3. Is this letter urgent? How can you tell?
+4. What documents do you need to prepare based on this letter?
+
+---
+
+*This document should be updated as BriefBot collects real user feedback and usage data.*

--- a/docs/research/swiss-official-correspondence-guide.md
+++ b/docs/research/swiss-official-correspondence-guide.md
@@ -1,0 +1,630 @@
+# Swiss Official Correspondence Guide
+
+A comprehensive reference manual for understanding official mail received by Swiss residents. This document serves as domain knowledge for AI-powered document analysis and translation.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Document Categories](#document-categories)
+3. [Issuing Institutions](#issuing-institutions)
+4. [Document Characteristics](#document-characteristics)
+5. [Common Pain Points](#common-pain-points)
+6. [Terminology Glossary](#terminology-glossary)
+7. [Payment Systems](#payment-systems)
+8. [Deadlines and Consequences](#deadlines-and-consequences)
+9. [Sources](#sources)
+
+---
+
+## Overview
+
+Switzerland's administrative system is characterized by its federalist structure with three levels of government: federal (Bund), cantonal (Kanton), and municipal (Gemeinde). Each level sends various types of official correspondence to residents, often in one of four national languages: German, French, Italian, or Romansh.
+
+### Key Statistics
+
+- **26 cantons**, each with its own administrative practices
+- **Over 2,100 municipalities** (Gemeinden)
+- **4 official languages** (German 62%, French 23%, Italian 8%, Romansh <1%)
+- All official documents written in **Standard German** (Hochdeutsch/Schriftdeutsch), not Swiss German dialects
+
+---
+
+## Document Categories
+
+### 1. Tax Documents (Steuern)
+
+#### Steuererklärung (Tax Return)
+
+- **Sender**: Cantonal tax authority (Steueramt/Kantonale Steuerverwaltung)
+- **Frequency**: Annual (sent January-March)
+- **Deadline**: March 31 (varies by canton), extensions available
+- **Content**: Forms for declaring income, wealth, deductions
+- **Key forms**:
+  - Main form (Hauptformular)
+  - Securities and credit balances (Wertschriften und Guthaben)
+  - Occupational expenses (Berufsauslagen)
+  - Insurance premiums (Versicherungsprämien)
+  - Deductions (Abzüge)
+- **Required attachments**:
+  - Salary certificate (Lohnausweis)
+  - Pension certificate (Rentenbescheinigung)
+  - Pillar 3a contributions proof
+  - Health insurance premium statements
+
+#### Steuerrechnung (Tax Bill)
+
+- **Sender**: Cantonal and municipal tax authorities
+- **Frequency**: After tax assessment (typically summer/fall)
+- **Payment deadline**: Usually 30 days
+- **Components**: Federal tax + Cantonal tax + Municipal tax
+- **Payment options**: Often 3 installments (May, July, September in some cantons)
+
+#### Provisional Tax Bill (Provisorische Steuerrechnung)
+
+- **Purpose**: Advance payments based on estimated income
+- **Timing**: Throughout the tax year
+- **Note**: Adjusted after final assessment
+
+### 2. Health Insurance (Krankenversicherung)
+
+#### Obligatory Health Insurance (Grundversicherung)
+
+- **Key documents**:
+  - Insurance policy (Police)
+  - Premium invoices (Prämienrechnung)
+  - Annual premium adjustment letter
+  - Franchise selection form
+  - Tax certificate for deductions (sent January)
+- **Deadline**: Must obtain insurance within 3 months of arriving in Switzerland
+- **Penalties**: Retroactive coverage at higher rates if delayed
+
+#### Health Insurance Subsidy (Prämienverbilligung)
+
+- **Sender**: Cantonal compensation office
+- **Eligibility**: Based on previous year's tax return
+- **Process**: Some cantons contact you automatically; others require application
+
+### 3. Social Security Documents
+
+#### AHV/AVS (Old Age and Survivors Insurance - 1st Pillar)
+
+- **Key documents**:
+  - AHV card (Versicherungsausweis) - credit card sized
+  - Individual account statement (Kontoauszug IK)
+  - Pension calculation/entitlement letters
+- **AHV Number format**: 756.XXXX.XXXX.XX (13 digits, 756 = Switzerland)
+- **Where to find**: Health insurance card, official correspondence
+
+#### IV/AI (Disability Insurance)
+
+- **Sender**: Cantonal IV office (IV-Stelle)
+- **Key documents**:
+  - Application confirmation
+  - Medical assessment requests
+  - Benefit decision (Verfügung)
+  - Rehabilitation measure notifications
+- **Important**: "Rehabilitation before pension" principle
+- **Waiting period**: 1 year with 40%+ incapacity for pension eligibility
+
+#### BVG/LPP (Occupational Pension - 2nd Pillar)
+
+- **Sender**: Employer's pension fund (Pensionskasse)
+- **Key documents**:
+  - Pension certificate (Vorsorgeausweis) - annual statement
+  - Vested benefits statement (Freizügigkeitsausweis)
+  - Contribution confirmations
+- **Content**: Retirement assets, death/disability benefits, contribution history
+- **Key terms**:
+  - Mandatory portion (obligatorischer Teil)
+  - Extra-mandatory portion (überobligatorischer Teil)
+  - Conversion rate (Umwandlungssatz) - currently 6.8% for mandatory
+  - Vested benefits (Freizügigkeitsleistung)
+
+#### SUVA (Accident Insurance)
+
+- **Applies to**: Employees in certain industries
+- **Key documents**:
+  - Accident report form
+  - Benefit decisions
+  - Rehabilitation notifications
+- **Coverage**: Occupational and non-occupational accidents (if working 8+ hours/week)
+- **Benefits**: 80% salary from day 3, no deductible for medical costs
+
+### 4. Immigration and Residence Permits
+
+#### Permit Types
+
+| Permit | Name | Duration | Notes |
+|--------|------|----------|-------|
+| **L** | Kurzaufenthaltsbewilligung | <1 year | Short-term |
+| **B** | Aufenthaltsbewilligung | 5 years (EU/EFTA) | Residence permit |
+| **C** | Niederlassungsbewilligung | Indefinite | Permanent residence |
+| **G** | Grenzgängerbewilligung | 5 years | Cross-border commuter |
+
+#### Key Documents
+
+- **Sender**: Cantonal migration office (Migrationsamt)
+- **Documents**:
+  - Permit card (Ausländerausweis)
+  - Renewal notices
+  - Status change notifications
+  - Integration requirement letters (language courses)
+- **Critical deadlines**:
+  - Apply within 14 days of arrival
+  - Renewal applications before expiry
+- **Language requirements**: A1+ level of cantonal language for B permit renewal (since 2019)
+
+### 5. Municipal Communications (Gemeinde)
+
+#### Resident Registration (Einwohnerkontrolle)
+
+- **Key documents**:
+  - Registration confirmation (Anmeldebestätigung)
+  - Deregistration confirmation (Abmeldebestätigung)
+  - Address change confirmation
+- **Deadlines**: Register/deregister within 14 days of moving
+- **Required for registration**:
+  - Health insurance proof
+  - Rental/purchase contract
+  - ID/passport
+  - Family documents (if applicable)
+
+#### Civil Registry (Zivilstandsamt)
+
+- **Documents issued**:
+  - Birth certificate (Geburtsurkunde)
+  - Marriage certificate (Heiratsurkunde)
+  - Death certificate (Todesurkunde)
+  - Family certificate (Familienausweis)
+- **Costs**: CHF 30+ per certificate
+- **Validity**: 3-6 months in most cases
+- **Birth registration deadline**: Within 3 days
+
+### 6. Vehicle and Traffic
+
+#### Vehicle Registration (Strassenverkehrsamt)
+
+- **Documents**:
+  - Vehicle registration document (Fahrzeugausweis)
+  - Number plates (Kontrollschilder)
+  - Vehicle inspection notice (MFK - Motorfahrzeugkontrolle)
+  - Road tax invoice (Motorfahrzeugsteuer)
+- **MFK schedule**:
+  - New cars: First inspection after 5 years
+  - Then every 3 years
+  - Later every 2 years
+- **Road tax**: CHF 100-800/year depending on canton and vehicle
+
+#### Traffic Fines (Verkehrsbussen)
+
+- **Types**:
+  - Ordnungsbussen (administrative fines) - minor violations
+  - Criminal proceedings - serious violations
+- **Parking fines**: CHF 40-100
+- **Speeding consequences**: Fines, warnings, license revocation
+- **Payment deadline**: Usually 30 days
+- **Non-payment**: Debt collection, wage garnishment, substitute imprisonment
+
+### 7. Utilities and Fees
+
+#### Serafe (Radio/TV Fee)
+
+- **Replaced**: Billag (since 2019)
+- **Annual fee**: CHF 335
+- **Billing**: Once per year (month varies by household group)
+- **Exemptions**: AHV/IV supplementary benefit recipients, deafblind persons
+- **Non-payment**: Debt collection (110,000+ cases in 2024)
+
+#### Utility Bills
+
+- **Electricity**: EWZ (Zurich), cantonal/municipal providers
+- **Water/sewage**: Municipal
+- **Waste disposal**: Often via official garbage bags (Kehrichtsäcke)
+
+### 8. Customs (Zoll/BAZG)
+
+#### Import Notifications
+
+- **Sender**: BAZG (Federal Office for Customs and Border Security)
+- **Triggers**: Packages from abroad exceeding thresholds
+- **Thresholds**:
+  - VAT: Items worth CHF 150+
+  - Customs duty: Amounts over CHF 5
+  - Gifts: Exempt up to CHF 100
+- **VAT rates**: 8.1% standard, 2.6% reduced (food, books, medicine)
+- **Service fees**: CHF 13-16 + 3% of goods value (Swiss Post)
+
+---
+
+## Issuing Institutions
+
+### Federal Level (Bund)
+
+| Institution | German | French | Responsibilities |
+|-------------|--------|--------|------------------|
+| Federal Tax Administration | Eidgenössische Steuerverwaltung (ESTV) | Administration fédérale des contributions (AFC) | Direct federal tax |
+| State Secretariat for Migration | Staatssekretariat für Migration (SEM) | Secrétariat d'État aux migrations | Immigration policy |
+| Federal Social Insurance Office | Bundesamt für Sozialversicherungen (BSV) | Office fédéral des assurances sociales | AHV/IV oversight |
+| Customs | Bundesamt für Zoll und Grenzsicherheit (BAZG) | Office fédéral de la douane et de la sécurité des frontières | Import duties |
+| BAKOM | Bundesamt für Kommunikation | Office fédéral de la communication | Broadcasting fees |
+
+### Cantonal Level (Kanton)
+
+| Office Type | German | French | Responsibilities |
+|-------------|--------|--------|------------------|
+| Tax Office | Kantonales Steueramt | Administration fiscale cantonale | Cantonal/municipal taxes |
+| Migration Office | Migrationsamt | Office de la population | Residence permits |
+| Road Traffic Office | Strassenverkehrsamt | Service des automobiles | Vehicle registration |
+| IV Office | IV-Stelle | Office AI | Disability insurance |
+| Social Insurance Office | Sozialversicherungsamt | Office des assurances sociales | Benefits coordination |
+
+### Municipal Level (Gemeinde)
+
+| Office Type | German | French | Responsibilities |
+|-------------|--------|--------|------------------|
+| Municipal Admin | Gemeindeverwaltung | Administration communale | General administration |
+| Resident Services | Einwohnerkontrolle | Contrôle des habitants | Registration |
+| Civil Registry | Zivilstandsamt | État civil | Birth/marriage/death |
+| Tax Office | Gemeindesteuerverwaltung | Administration fiscale communale | Municipal taxes |
+
+### Semi-Public Organizations
+
+| Organization | Type | Sends |
+|--------------|------|-------|
+| Health insurers (CSS, Helsana, Swica, etc.) | Private, regulated | Premiums, coverage docs |
+| Pension funds (Pensionskassen) | Semi-public | Annual statements |
+| SUVA | Public accident insurer | Accident-related correspondence |
+| Serafe AG | Public mandate | TV/radio fee invoices |
+| AHV compensation funds (Ausgleichskassen) | Semi-public | Contribution statements |
+
+---
+
+## Document Characteristics
+
+### Language Variations
+
+#### German-Speaking Switzerland (Deutschschweiz)
+
+- **Written language**: Swiss Standard German (Schweizer Hochdeutsch/Schriftdeutsch)
+- **Key difference from German German**: No ß (replaced by ss)
+- **NOT Swiss German**: Official documents are never in dialect (Schwyzerdütsch)
+- **Bureaucratic style**: Formal, technical, long compound words
+
+#### French-Speaking Switzerland (Romandie)
+
+- **Cantons**: Geneva, Vaud, Neuchâtel, Jura, parts of Bern, Fribourg, Valais
+- **Style**: Standard French with Swiss administrative terminology
+
+#### Italian-Speaking Switzerland (Svizzera Italiana)
+
+- **Canton**: Ticino, parts of Graubünden
+- **Style**: Standard Italian with Swiss legal terms
+
+#### Romansh-Speaking Areas
+
+- **Region**: Parts of Graubünden
+- **Usage**: Limited official correspondence
+
+### Typical Document Structure
+
+1. **Header**: Sender logo, address, reference numbers
+2. **Subject line** (Betreff/Objet): Clear statement of purpose
+3. **Greeting**: Formal (Sehr geehrte/r... / Madame, Monsieur)
+4. **Body**: Legal basis, explanation, required actions
+5. **Deadlines**: Prominently displayed (Frist/Délai)
+6. **Payment section**: Often includes QR-bill
+7. **Appeals information** (Rechtsmittelbelehrung): How to contest
+8. **Contact information**: Office hours, phone, email
+9. **Signature**: Official signature or stamp
+
+### Common Formatting Elements
+
+- **Bold deadlines** with date and time
+- **Reference numbers** (Dossiernummer, Referenznummer)
+- **Legal citations** (Art. XX Abs. Y)
+- **Tables** for calculations
+- **QR-bills** for payments
+- **Checkboxes** for required actions
+
+---
+
+## Common Pain Points
+
+### Why Documents Are Difficult
+
+#### 1. Legal/Bureaucratic Language (Amtsdeutsch)
+
+- **Long compound nouns**: Einkommenssteuerveranlagungsverfügung
+- **Passive constructions**: "Es wird verfügt..." instead of "Wir verfügen..."
+- **Nominalizations**: Converting verbs to nouns
+- **Legal jargon**: References to laws, articles, paragraphs
+- **Abbreviations**: AHV, IV, BVG, EO, ALV, NBUV, etc.
+
+#### 2. Cultural Assumptions
+
+- Documents assume familiarity with the Swiss system
+- No explanations of basic concepts
+- References to other documents/laws without context
+- Expectation that recipients know which office handles what
+
+#### 3. Consequences Not Clear
+
+- Penalties buried in fine print
+- Escalation process not obvious
+- Timeline for enforcement not stated
+- Multiple reminder fees not itemized
+
+### What Non-Native Speakers Struggle With
+
+#### Language Barriers
+
+- Technical vocabulary not in standard dictionaries
+- Different terminology in different cantons
+- Mixed German/French terms in border regions
+- Swiss-specific expressions
+
+#### Process Confusion
+
+- Which office to contact
+- What documents to provide
+- Order of operations (e.g., deregister before register)
+- Difference between "must" and "may" in legal text
+
+#### Payment Systems
+
+- Understanding QR-bills
+- Bank transfer mechanics
+- Payment deadlines vs. processing time
+- Installment options
+
+#### Implicit Knowledge
+
+- Swiss residents grow up learning the system
+- Expats lack decades of accumulated knowledge
+- Schools don't teach administrative literacy
+- Friends/colleagues may not know English terms
+
+### Consequences of Misunderstanding
+
+#### Financial
+
+| Consequence | Trigger | Typical Amount |
+|-------------|---------|----------------|
+| Late payment interest | Missing deadline | 4-5% annual |
+| Reminder fee | Each reminder | CHF 20-50 |
+| Discretionary assessment | No tax return | Higher tax + penalty |
+| Debt collection costs | Unpaid bills | CHF 50-200+ |
+| Fines | Missed registration | CHF 100-1000 |
+
+#### Administrative
+
+- **Betreibung** (debt collection): Public record visible to landlords, employers
+- **Permit issues**: Delays or denial of residence permit renewal
+- **Credit score impact**: Affects ability to rent, get loans
+- **Criminal proceedings**: For serious violations (tax evasion, traffic)
+
+#### Personal
+
+- **Stress and anxiety**: Incomprehensible documents feel threatening
+- **Time loss**: Hours spent researching, translating, calling offices
+- **Dependency**: Reliance on Swiss friends/colleagues for help
+- **Integration barriers**: Feeling excluded from society
+
+---
+
+## Terminology Glossary
+
+### General Administrative Terms
+
+| German | French | Italian | English |
+|--------|--------|---------|---------|
+| Bescheid | Décision | Decisione | Decision/notice |
+| Verfügung | Décision | Decisione | Ruling/order |
+| Frist | Délai | Termine | Deadline |
+| Einsprache | Opposition | Opposizione | Objection |
+| Beschwerde | Recours | Ricorso | Appeal |
+| Mahnung | Rappel | Sollecito | Reminder |
+| Gebühr | Taxe | Tassa | Fee |
+| Beilage | Annexe | Allegato | Attachment |
+| Rechtsmittel | Voie de recours | Rimedio giuridico | Legal remedy |
+| Zuständig | Compétent | Competente | Responsible/competent |
+
+### Tax Terms
+
+| German | French | English |
+|--------|--------|---------|
+| Steuererklärung | Déclaration d'impôts | Tax return |
+| Steuerrechnung | Avis d'imposition | Tax bill |
+| Veranlagung | Taxation | Assessment |
+| Abzug | Déduction | Deduction |
+| Einkommen | Revenu | Income |
+| Vermögen | Fortune | Wealth/assets |
+| Quellensteuer | Impôt à la source | Withholding tax |
+| Stundung | Sursis | Deferral |
+| Verzugszins | Intérêt moratoire | Late interest |
+
+### Insurance Terms
+
+| German | French | English |
+|--------|--------|---------|
+| Prämie | Prime | Premium |
+| Franchise | Franchise | Deductible |
+| Selbstbehalt | Quote-part | Co-pay |
+| Deckung | Couverture | Coverage |
+| Leistung | Prestation | Benefit |
+| Anspruch | Droit | Entitlement |
+| Beitrag | Cotisation | Contribution |
+
+### Immigration Terms
+
+| German | French | English |
+|--------|--------|---------|
+| Aufenthaltsbewilligung | Autorisation de séjour | Residence permit |
+| Niederlassungsbewilligung | Autorisation d'établissement | Settlement permit |
+| Verlängerung | Prolongation | Extension |
+| Antrag | Demande | Application |
+| Nachweis | Justificatif | Proof/evidence |
+
+---
+
+## Payment Systems
+
+### QR-Bill (Since 2022)
+
+The QR-bill replaced orange and red payment slips (Einzahlungsscheine) in October 2022.
+
+#### Structure
+
+```
+┌─────────────────────────────────────────────────┐
+│                                                 │
+│              INVOICE CONTENT                    │
+│                                                 │
+├─────────────────────────────────────────────────┤
+│  Receipt          │        Payment Part         │
+│  (Empfangsschein) │        (Zahlteil)          │
+│                   │                             │
+│  [Swiss QR Code]  │     [Large QR Code]        │
+│                   │                             │
+│  Amount: CHF xxx  │     Amount: CHF xxx        │
+│  Account: xxx     │     Account: xxx           │
+│  Reference: xxx   │     Reference: xxx         │
+│  Payable to: xxx  │     Payable to: xxx        │
+│  Payable by: xxx  │     Payable by: xxx        │
+└─────────────────────────────────────────────────┘
+```
+
+#### Key Elements
+
+- **Swiss QR Code**: Contains all payment information
+- **Account**: IBAN or QR-IBAN (5th-6th digits are 30 or 31)
+- **Reference**: QR reference or creditor reference (SCOR)
+- **Amount**: CHF or EUR
+- **Payment information**: Additional details
+
+#### Payment Methods
+
+1. **Mobile banking**: Scan QR code with banking app
+2. **E-banking**: Upload QR code image or enter details manually
+3. **Post office**: Present at counter
+4. **Bank counter**: Present at bank branch
+
+### Bank Transfer (Überweisung)
+
+For payments without QR-bill:
+
+- **Required**: IBAN, recipient name, amount, reference number
+- **Optional**: BIC/SWIFT for international transfers
+
+---
+
+## Deadlines and Consequences
+
+### Critical Deadlines Summary
+
+| Document Type | Typical Deadline | Consequence of Missing |
+|---------------|------------------|----------------------|
+| Tax return | March 31 | Reminder fee, discretionary assessment |
+| Tax payment | 30 days | Late interest (4-5% p.a.) |
+| Health insurance enrollment | 3 months after arrival | Retroactive premiums, penalties |
+| Residence registration | 14 days | Fine CHF 100+ |
+| Permit renewal | Before expiry | Gap in legal status |
+| Traffic fine | 30 days | Debt collection |
+| Serafe fee | As invoiced | Debt collection |
+| Birth registration | 3 days | Administrative issues |
+
+### Escalation Process (Typical)
+
+1. **Initial invoice/notice** - 30 days to respond
+2. **First reminder (1. Mahnung)** - 14-30 days, fee CHF 20-30
+3. **Second reminder (2. Mahnung)** - 14 days, fee CHF 30-50
+4. **Final warning (letzte Mahnung)** - 10 days, fee + threat of collection
+5. **Debt collection (Betreibung)** - Legal process initiated
+   - Zahlungsbefehl (payment order)
+   - Rechtsvorschlag possible (objection)
+   - Pfändung (seizure) or bankruptcy
+
+### Betreibung (Debt Collection) Impact
+
+- **Public record**: Visible in Betreibungsregisterauszug
+- **Duration**: Entries remain 5 years (or longer if disputed)
+- **Affects**: Rental applications, employment checks, loans
+- **Removal**: Possible with creditor consent after payment
+
+---
+
+## Sources
+
+### Official Government Resources
+
+- [ch.ch - Official Information Portal](https://www.ch.ch/en/)
+- [Tax Return Information](https://www.ch.ch/en/taxes-and-finances/tax-return/)
+- [Residence Permits](https://www.ch.ch/en/documents-and-register-extracts/permits-for-living-in-switzerland/)
+- [Civil Status Certificates](https://www.ch.ch/en/documents-and-register-extracts/civil-status-certificates/)
+- [Traffic Regulations and Fines](https://www.ch.ch/en/vehicles-and-traffic/how-to-behave-in-road-traffic/traffic-regulations/traffic-regulations-and-fines-in-switzerland/)
+- [Accident Insurance](https://www.ch.ch/en/insurance/accident-insurance/)
+- [Disability Insurance](https://www.ch.ch/en/insurance/disability-insurance--di/iv/ai-/)
+- [Second Pillar Information](https://www.ch.ch/en/retirement/old-age-pension/the-2nd-pillar/)
+
+### Social Insurance
+
+- [AHV/IV Information Center](https://www.ahv-iv.ch/en/)
+- [Federal Social Insurance Office - Invalidity Insurance](https://www.bsv.admin.ch/bsv/en/home/social-insurance/iv.html)
+- [Suva - Accident Insurance](https://www.suva.ch/en/)
+
+### Migration
+
+- [State Secretariat for Migration - B Permit](https://www.sem.admin.ch/sem/en/home/themen/aufenthalt/eu_efta/ausweis_b_eu_efta.html)
+
+### Customs
+
+- [BAZG - Importation](https://www.bazg.admin.ch/bazg/en/home/information-individuals/online-shopping--mail-and-courier-consignments/importation-into-switzerland.html)
+- [BAZG - Tax-Free Limits](https://www.bazg.admin.ch/bazg/en/home/information-individuals/travel-and-purchases--allowances-and-duty-free-limit/importation-into-switzerland/tax-free-limit.html)
+
+### Payments
+
+- [QR-Bill FAQ - Moneyland](https://www.moneyland.ch/en/qr-bill-payment-slips-switzerland)
+- [QR-Bill - UBS](https://www.ubs.com/ch/en/services/payments/pay-invoices/qrbill/faq.html)
+- [Serafe - Radio/TV Fees](https://www.serafe.ch/en)
+
+### Tax Information
+
+- [PWC Tax Summaries - Switzerland](https://taxsummaries.pwc.com/switzerland/individual/tax-administration)
+- [Tax Deadlines - Taxolution](https://www.taxolution.ch/swiss-tax-guide/tax-deadlines-2025/)
+- [Zurich Tax Return Guide](https://www.weiach.ch/public/upload/assets/1436/How%20to%20Fill%20in%20Your%20Tax%20Return.pdf)
+
+### Expat Resources
+
+- [Expatica - Health Insurance Guide](https://www.expatica.com/ch/healthcare/healthcare-basics/a-guide-to-swiss-health-insurance-693473/)
+- [Comparis - Residence Permits](https://en.comparis.ch/neu-in-der-schweiz/auswandern/aufenthaltsbewilligung)
+- [Comparis - Motor Vehicle Tax](https://en.comparis.ch/carfinder/autofahren/motorfahrzeugsteuer)
+- [Comparis - Road Traffic Office](https://en.comparis.ch/autoversicherung/neues-auto/strassenverkehrsamt)
+- [Swiss Forum - Expat Discussions](https://swissforum.co.uk/)
+
+### Pension and Insurance
+
+- [Swiss Life - 2nd Pillar](https://www.swisslife.ch/en/individuals/future-provisions-assets/2nd-pillar.html)
+- [AXA - Pillar 2](https://www.axa.ch/en/pension/pillar-2.html)
+- [Comparis - Occupational Pension](https://en.comparis.ch/altersvorsorge/bvg)
+
+### Language and Communication
+
+- [Wikipedia - Swiss Standard German](https://en.wikipedia.org/wiki/Swiss_Standard_German)
+- [The Local - Swiss German vs Hochdeutsch](https://www.thelocal.ch/20221206/swiss-german-vs-hochdeutsch-what-are-the-key-differences)
+
+---
+
+## Document for BriefBot Domain Expert Agent
+
+*This reference manual provides the foundational knowledge needed for:*
+
+1. **OCR Processing**: Understanding document structure, headers, reference numbers
+2. **Translation**: Accurate rendering of technical/legal terms
+3. **Explanation**: Providing context about Swiss administrative processes
+4. **Action Extraction**: Identifying deadlines, required responses, payment amounts
+5. **Risk Assessment**: Flagging urgent items, potential consequences
+6. **Guidance**: Suggesting next steps, relevant offices to contact
+
+*Last updated: January 2026*


### PR DESCRIPTION
## Summary

- Add comprehensive domain research for Swiss official correspondence
- Create two new specialized agents (domain-expert, market-analyst)
- Add knowledge reference documents for agent use
- Update CLAUDE.md with new workflow

## Research Documents Created

| Document | Purpose |
|----------|---------|
| `docs/research/swiss-official-correspondence-guide.md` | 8 document categories, institutions, pain points |
| `docs/research/USER_PERSONAS.md` | 5 user personas with journey maps |
| `docs/MARKET_ANALYSIS.md` | Market size, competition, monetization strategy |
| `docs/SWISS_TERMINOLOGY_GLOSSARY.md` | DE/FR/IT/EN terminology reference |

## New Agents

| Agent | Role |
|-------|------|
| `domain-expert` | Swiss domain expertise, product owner, feature validation |
| `market-analyst` | Business strategy, pricing, go-to-market planning |

## Knowledge Documents

Quick reference docs in `.claude/knowledge/`:
- `SWISS_DOMAIN.md` - Key abbreviations, deadlines, document types
- `USER_CONTEXT.md` - Persona summaries, pain points, success metrics

## Updated Workflow

```
1. domain-expert       → Validate user need & priority
2. /plan or planner    → Define what to build  
3. architect + ux-designer (parallel) → Design solution
4. Implement with TDD
5. reviewer or /review → Validate before commit
6. npm run pre-pr      → Local validation
7. gh pr create        → Create PR
```

## Test plan

- [x] Documentation files are valid markdown
- [x] Agent files follow existing structure
- [x] CLAUDE.md updates are consistent
- [ ] CI passes (lint, type-check, build)